### PR TITLE
add db connection error handling and testing

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -224,7 +224,15 @@ var Read = Juttle.proc.source.extend({
 
         executeQuery()
         .catch(function(err) {
-            self.trigger('error', self.runtime_error('RT-INTERNAL-ERROR', { error: err.message.toString() }));
+            if (/Pool (is|was) destroyed/.test(err.message)) {
+                var connectionInfo = self.baseQuery.client.connectionSettings ;
+                
+                self.trigger('error', self.runtime_error('RT-INTERNAL-ERROR', {
+                    error: 'could not connect to database: ' + JSON.stringify(connectionInfo)
+                }));
+            } else {
+                self.trigger('error', self.runtime_error('RT-INTERNAL-ERROR', { error: err.message.toString() }));
+            }
         }).finally(function() {
             self.eof();
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juttle-sql-adapter-common",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Code shared by Juttle adapters for SQL databases",
   "keywords": ["juttle", "adapter", "sql"],
   "homepage": "https://github.com/juttle/juttle-sql-adapter-common",
@@ -27,7 +27,7 @@
     "jscs": "^2.6.0"
   },
   "peerDependencies": {
-    "juttle": "^0.1.x"
+    "juttle": "^0.1.0"
   },
   "engines": {
     "node": ">=4.2.0",

--- a/test/db.spec.js
+++ b/test/db.spec.js
@@ -1,0 +1,31 @@
+var expect = require('chai').expect;
+var TestUtils = require("./utils");
+var check_juttle = TestUtils.check_sql_juttle;
+var AdapterClass = require('../');
+
+describe('test db connection error', function () {
+    before(function() {
+        var config = {
+            "knex_conf" : {
+                "client": "sqlite3",
+                "connection": {
+                    filename: "./not_dir/not_dir/not_db.sqlite"
+                }
+            }
+        };
+        var sqlTest = function(conf) {
+            var sql = AdapterClass.call(this, conf);
+            sql.name = 'sqltest';
+            return sql;
+        };
+        return TestUtils.init(config, sqlTest);
+    });
+    it('error on incorrect connection string or credentials', function() {
+        return check_juttle({
+            program: 'read sql -table "fake"'
+        })
+        .then(function(result) {
+            expect(result.errors[0]).to.contain('could not connect to database');
+        });
+    });
+});

--- a/test/shared-sql.spec.js
+++ b/test/shared-sql.spec.js
@@ -18,6 +18,8 @@ function SharedSqlTests() {
         });
 
         require('./write.spec');
+
+        require('./db.spec');
     });
 }
 module.exports = SharedSqlTests;


### PR DESCRIPTION
Current: Throws all `connection pools destroyed` error when invalid
connection.
Now: Throws a `cannot make connection` error and adds connection params
used.