### PR TITLE
Drop sourceType property from read

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -9,7 +9,6 @@ var Promise = require('bluebird');
 var logger = require('juttle/lib/logger').getLogger('sql-db-read');
 
 var Read = Juttle.proc.source.extend({
-    sourceType: 'batch',
     procName: 'read-sql',
     FETCH_SIZE_LIMIT: 10000,
 


### PR DESCRIPTION
As read now inherits from Juttle source proc and program checks for
that, the sourceType property is not needed.

refs: https://github.com/juttle/juttle/pull/110