### PR TITLE
Ensure lint failures are travis failures.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "mocha test/run.spec.js",
     "jshint": "jshint *.js test/*.js lib/*.js",
     "style": "jscs *.js test/*.js lib/*.js",
-    "lint": "npm run jshint & npm run style"
+    "lint": "npm run jshint && npm run style"
   },
   "dependencies": {
     "knex": "^0.9.0",


### PR DESCRIPTION
Add missing && which was messing with the return value from the jshint
command.

@mnibecker you're an expert on this now!