### PR TITLE
package.json: depend on juttle >= 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jscs": "^2.6.0"
   },
   "peerDependencies": {
-    "juttle": "^0.2.0"
+    "juttle": ">=0.2.0"
   },
   "engines": {
     "node": ">=4.2.0",


### PR DESCRIPTION
Relax the dependency on juttle so that we don't depend on a specific
minor release but instead depend on juttle >= 0.2.0.

Relates to https://github.com/juttle/juttle/issues/145