### PR TITLE
Add support for serializing objects/arrays

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -1,7 +1,7 @@
 var _ = require('underscore');
 var db = require('./db');
 var Juttle = require('juttle/lib/runtime').Juttle;
-var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var values = require('juttle/lib/runtime/values');
 
 var logger = require('juttle/lib/logger').getLogger('sql-db-write');
 
@@ -46,9 +46,25 @@ var Write = Juttle.proc.sink.extend({
     },
 
     formatPoints: function(points) {
+        var self = this;
+
+        points = _.filter(points, function(pt) {
+            var deep = _.some(pt, function(value, key) {
+                return values.isObject(value) || values.isArray(value);
+            });
+
+            if (deep) {
+                self.trigger('warning', self.runtime_error('RT-INTERNAL-ERROR', {
+                    error: 'Serializing array and object fields is not supported.'
+                }));
+            }
+
+            return !deep;
+        });
+
         _.each(points, function(pt) {
             _.each(pt, function(value, key) {
-                if (value instanceof JuttleMoment) {
+                if (values.isDate(value) || values.isDuration(value)) {
                     pt[key] = new Date(value.valueOf());
                 }
             });
@@ -59,6 +75,8 @@ var Write = Juttle.proc.sink.extend({
 
     insertPoints: function(points) {
         var self = this;
+
+        if (points.length === 0) { return; }
 
         this.inserts_in_progress++;
 

--- a/test/write.spec.js
+++ b/test/write.spec.js
@@ -42,6 +42,17 @@ describe('write proc', function () {
             expect(pt_time).gt(Date.parse(yesterday));
         });
     });
+
+    it('write array/object fields triggers a warning', function() {
+        return check_juttle({
+            program: 'emit -limit 1 | put a = { key: "val", arr: [1,2,3] } | put b = "test" | write sql -table "sqlwriter"'
+        })
+        .then(function(result) {
+            expect(result.warnings).to.not.have.length(0);
+            expect(result.warnings[0]).to.include('not supported');
+        });
+    });
+
     it('write proc error when fields do not match columns', function() {
         return check_juttle({
             program: 'emit -limit 1 | put c = "hi" | put d = "yes" | write sql -table "sqlwriter"'


### PR DESCRIPTION
As core Juttle now handles fields whose values are arrays or objects,
add support for serializing those points into JSON.