### PR TITLE
add: tail optimization

### DIFF
--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -3,6 +3,7 @@ var _ = require('underscore');
 var reducers = require('juttle/lib/runtime/reducers').reducers;
 
 var ALLOWED_REDUCE_OPTIONS = ['forget', 'groupby', 'every', 'on'];
+var FETCH_SIZE_LIMIT = 10000;
 
 function _getFieldName(node) {
     return node.expression.value;
@@ -62,6 +63,32 @@ var optimizer = {
         }
 
         optimization_info.type = 'head';
+        optimization_info.limit = limit;
+        return true;
+    },
+    optimize_tail: function(read, tail, graph, optimization_info) {
+        if (optimization_info.type && optimization_info.type !== 'tail') {
+            logger.debug('optimization aborting -- cannot append tail optimization to prior',
+                optimization_info.type, 'optimization');
+            return false;
+        }
+
+        var limit = graph.node_get_option(tail, 'arg');
+        if (optimization_info.hasOwnProperty('limit')) {
+            limit = Math.min(limit, optimization_info.limit);
+        }
+
+        var fetchSize = graph.node_get_option(read, 'fetchSize') || FETCH_SIZE_LIMIT;
+        if (fetchSize < limit) {
+            // Doesn't make sense to reverse multiple pages of results in the adapter.
+            logger.debug('optimization aborting -- fetchSize cannot be less than tail limit', {
+                tail_limit: limit,
+                fetchSize: fetchSize
+            });
+            return false;
+        }
+
+        optimization_info.type = 'tail';
         optimization_info.limit = limit;
         return true;
     },

--- a/lib/read.js
+++ b/lib/read.js
@@ -41,9 +41,9 @@ var Read = Juttle.proc.source.extend({
 
         this.baseQuery = this.baseQuery.from(options.table).limit(this.getNextLimit());
 
-        //cannot order by time with any reduces
+        //cannot order by time with any optimized reduce
         if (this.timeField && !(params.optimization_info && params.optimization_info.type === 'reduce')) {
-            this.baseQuery = this.baseQuery.orderBy(this.timeField || 'time');
+            this.baseQuery = this.baseQuery.orderBy(this.timeField || 'time', this.tailOptimized ? 'desc' : 'asc');
         }
     },
 
@@ -98,9 +98,10 @@ var Read = Juttle.proc.source.extend({
         var self = this;
         if (optimization_info && !_.isEmpty(optimization_info)) {
             logger.debug('adding optimizations: ', optimization_info);
-            if (optimization_info.type === 'head') {
-                logger.debug('head optimization, new max size: ', optimization_info.limit);
+            if (optimization_info.type === 'head' || optimization_info.type === 'tail') {
+                logger.debug(optimization_info.type + ' optimization, new max size: ', optimization_info.limit);
                 self.maxSize = optimization_info.limit;
+                self.tailOptimized = optimization_info.type === 'tail';
             }
             if (optimization_info.type === 'reduce') {
                 var groupby = optimization_info.groupby;
@@ -271,8 +272,7 @@ var Read = Juttle.proc.source.extend({
                     _.extend(pt, additionalFields);
                 });
             }
-
-            if (points.length < self.fetchSize || self.getNextLimit() <= 0) {
+            if (points.length < self.fetchSize) {
                 //no more pagination necessary
                 return self.formatAndSend(points);
             }
@@ -287,7 +287,7 @@ var Read = Juttle.proc.source.extend({
                 nextQuery = query.offset(self.offsetCount).limit(self.getNextLimit());
             }
 
-            if (nextQuery) {
+            if (nextQuery && self.getNextLimit() > 0) {
                 return self.paginate(nextQuery);
             }
         });
@@ -321,10 +321,11 @@ var Read = Juttle.proc.source.extend({
             }));
             return;
         }
+
         this.formatAndSend(nonBorderPoints);
 
         logger.debug('next pagination based on timefield ', sortField, ' with border value ', borderValue);
-        return query.where(sortField, '>=', new Date(borderValue));
+        return query.where(sortField, this.tailOptimized ? '<=' : '>=', new Date(borderValue));
     },
 
     formatAndSend: function(points) {
@@ -351,6 +352,10 @@ var Read = Juttle.proc.source.extend({
                 pt[self.timeField] = undefined;
             }
         });
+
+        if (this.tailOptimized) {
+            points.reverse();
+        }
 
         return JuttleUtils.toNative(points);
     },


### PR DESCRIPTION
Added the tail optimization. https://github.com/juttle/juttle-postgres-adapter/issues/11

Talked to @davidvgalbraith a bit and we decided to only optimize when `fetchSize` <  `tail limit`, in other words only non-paginated queries. The edge case where  `fetchSize` >  `tail limit` would be much more complex to optimize for and will not occur often. Why? - Because we would need to emit the last paginated result set first. instead of emitting each consecutive result set as the results are returned. 