### PR TITLE
use base class parseTime

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -2,7 +2,6 @@ var _ = require('underscore');
 var db = require('./db');
 var SQLFilter = require('./sql_filter');
 var Juttle = require('juttle/lib/runtime').Juttle;
-var JuttleUtils = require('juttle/lib/runtime/juttle-utils');
 var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
 var Promise = require('bluebird');
 
@@ -335,8 +334,6 @@ var Read = Juttle.proc.source.extend({
     },
 
     formatPoints: function(points) {
-        var self = this;
-
         if (this.addPointFormatting) {
             this.addPointFormatting(points, this.aggregation_targets);
         }
@@ -345,19 +342,11 @@ var Read = Juttle.proc.source.extend({
             points = this.handleNullAggregates(points);
         }
 
-        _.each(points, function(pt) {
-            //ensure time is in the "time" key of each point.
-            if (self.timeField && self.timeField !== 'time') {
-                pt.time = pt[self.timeField];
-                delete pt[self.timeField];
-            }
-        });
-
         if (this.tailOptimized) {
             points.reverse();
         }
 
-        return JuttleUtils.toNative(points);
+        return this.parseTime(points, this.timeField);
     },
 
     //handle trailing and leading null aggreates


### PR DESCRIPTION
Use parseTime instead of the same logic in the adapter. https://github.com/juttle/juttle-postgres-adapter/issues/13

@rlgomes @davidvgalbraith @dmehra 