### PR TITLE
Do not call JuttleMoment.duration with "new"

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -143,7 +143,7 @@ var Read = Juttle.proc.source.extend({
 
         function get_batch_offset_as_duration(every_duration) {
             try {
-                return new JuttleMoment.duration(reduce_on);
+                return JuttleMoment.duration(reduce_on);
             } catch (err) {
                 // translate a non-duration -on into the equivalent duration
                 // e.g. if we're doing -every :hour: -on :2015-03-16T18:32:00.000Z:
@@ -156,7 +156,7 @@ var Read = Juttle.proc.source.extend({
         function get_buckets() {
             var buckets = [query_start];
 
-            var duration = new JuttleMoment.duration(reduce_every);
+            var duration = JuttleMoment.duration(reduce_every);
             var zeroth_bucket = JuttleMoment.quantize(query_start, duration);
             var last_bucket = JuttleMoment.quantize(query_end, duration);
 


### PR DESCRIPTION
`JuttleMoment.duration` is not a constructor (just a factory function), so it should not be called using the `new` operator. This PR removes `new` from any such calls.