### PR TITLE
Require FilterJSCompiler directly

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -1,6 +1,7 @@
 var _ = require('underscore');
 var db = require('./db');
 var SQLFilter = require('./sql_filter');
+var FilterJSCompiler = require('juttle/lib/compiler/filters/filter-js-compiler');
 var Juttle = require('juttle/lib/runtime').Juttle;
 var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
 var Promise = require('bluebird');
@@ -70,7 +71,7 @@ var Read = Juttle.proc.source.extend({
     },
 
     addFilters: function(filter_ast) {
-        var FilterSQLCompiler = Juttle.FilterJSCompiler.extend(SQLFilter);
+        var FilterSQLCompiler = FilterJSCompiler.extend(SQLFilter);
         var compiler = new FilterSQLCompiler({ baseQuery: this.baseQuery });
         return compiler.compile(filter_ast);
     },


### PR DESCRIPTION
Instead of using `Juttle.FilterJSCompiler` to access `FilterJSCompiler`, require it directly. The `Juttle.FilterJSCompiler` property will cease to be available soon.

Part of work on juttle/juttle#97.