### PR TITLE
change knex and sqlite to devDep

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -5,13 +5,8 @@ var knex;
 var DB = {
     init: function(config) {
         if (config.knex) {
-            knex =  config.knex;
-            logger.info('using knex db connection object specified by conf file');
-        } else if (config.knex_conf) {
-            logger.info('using knex_conf to connect to db', config.knex_conf);
-            knex =  require('knex')(
-                config.knex_conf
-            );
+            knex = config.knex;
+            logger.info('initializing db connection with conf:', knex.client.config);
         } else {
             throw new Error('knex config for sql adapter not found.');
         }

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "check-coverage": "istanbul check-coverage"
   },
   "dependencies": {
-    "knex": "^0.9.0",
-    "sqlite3": "^3.1.1",
     "underscore": "^1.8.3",
     "bluebird": "^3.0.5"
   },
   "devDependencies": {
+    "sqlite3": "^3.1.1",
+    "knex": "^0.9.0",
     "chai": "^1.10.0",
     "eslint": "^1.10.3",
     "istanbul": "^0.4.2",

--- a/test/utils.js
+++ b/test/utils.js
@@ -5,7 +5,7 @@ var juttle_test_utils = require('juttle/test/runtime/specs/juttle-test-utils');
 var check_juttle = juttle_test_utils.check_juttle;
 var expect = require('chai').expect;
 var Juttle = require('juttle/lib/runtime').Juttle;
-var logger = require('juttle/lib/logger').getLogger('sql-time-test');
+var logger = require('juttle/lib/logger').getLogger('sql-test-util');
 
 var knex;
 var adapter;
@@ -21,7 +21,7 @@ var TestUtils = {
 
         adapter = AdapterClass(config);
 
-        logger.info('Testing ' + adapter.name + ' adapter with config:', config);
+        logger.info('Testing ' + adapter.name + ' adapter.');
 
         knex = adapter.knex;
 
@@ -51,18 +51,18 @@ var TestUtils = {
     },
     getAdapterConfig: function(useFake) {
         var real = {
-            "knex_conf" : {
+            knex: require('knex')({
                 "client": "sqlite3",
                 "connection": ":memory:"
-            }
+            })
         };
         var fake = {
-            "knex_conf" : {
+            knex: require('knex')({
                 "client": "sqlite3",
                 "connection": {
                     filename: "./not_dir/not_dir/not_db.sqlite"
                 }
-            }
+            })
         };
 
         return useFake ? fake : real;


### PR DESCRIPTION
Change `knex` and `sqlite` to dev dependency. Fixes https://github.com/juttle/juttle-sql-adapter-common/issues/30