### PR TITLE
ensure optimization unit tests are actually optimizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Common code shared among
 [MySQL](https://github.com/juttle/juttle-mysql-adapter/)
 and [SQLite](https://github.com/juttle/juttle-sqlite-adapter/) adapters.
 
+#### List of optimized operations
+
+* any filter expression `read sql` (note: `read sql | filter ...` is not optimized)
+* `head` or `tail`
+* `reduce count()`, `sum()`, `min()`, `max()`, `sum()`, `avg()`, `count_unique()`
+* `reduce by fieldname`
+* `reduce -every :interval:`
+
+In case of unexpected behavior with optimized reads, add `-optimize false` option to `read sql` to disable optimizations, and kindly report the problem as a GitHub issue.
+
 ## Contributing
 
 Contributions are welcome! Please file an issue or open a pull request.

--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -181,7 +181,11 @@ var optimizer = {
             };
         }
 
+        // expected by juttle
         var expect_empty_result = _.object(reduce.exprs.map(_expected_empty_reducer_result));
+
+        // Actual empty point match returned from optimized query:
+        //      currently the only difference is that actual empty sum is null while expected 0.
         var empty_result = _empty_reducer_result(aggrs);
 
         if (graph.node_has_option(reduce, 'every')) {

--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -2,8 +2,17 @@ var logger = require('juttle/lib/logger').getLogger('sql-db-optimizer');
 var _ = require('underscore');
 var reducers = require('juttle/lib/runtime/reducers').reducers;
 
-var ALLOWED_REDUCE_OPTIONS = ['forget', 'groupby', 'every', 'on'];
 var FETCH_SIZE_LIMIT = 10000;
+var ALLOWED_REDUCE_OPTIONS = ['forget', 'groupby', 'every', 'on'];
+var VALID_AGGREGATIONS = ['count', 'avg', 'sum', 'min', 'max', 'count_unique'];
+var EMPTY_AGGREGATE_VALS = {
+    avg: null,
+    min: null,
+    max: null,
+    sum: null,
+    count: 0,
+    count_unique: 0
+};
 
 function _getFieldName(node) {
     return node.expression.value;
@@ -19,8 +28,16 @@ function _isSimpleFieldReference(node) {
         node.expression.type === 'StringLiteral';
 }
 
-function _empty_reducer_result(expr) {
+function _expected_empty_reducer_result(expr) {
     return [_getFieldName(expr.left), reducers[_getReducerName(expr.right)].id];
+}
+
+function _empty_reducer_result(aggrs) {
+    var empty_result = {};
+    _.each(aggrs, function(val, target) {
+        empty_result[target] = EMPTY_AGGREGATE_VALS[val.name || 'count_unique'];
+    });
+    return empty_result;
 }
 
 function _isReducerCall(node) {
@@ -45,8 +62,6 @@ function reduce_expr_is_optimizable(expr) {
 
     return true;
 }
-
-var VALID_AGGREGATIONS = ['count', 'avg', 'sum', 'min', 'max', 'count_unqiue'];
 
 var optimizer = {
     optimize_head: function(read, head, graph, optimization_info) {
@@ -155,7 +170,7 @@ var optimizer = {
 
             if (reducer === 'count_unique') {
                 aggrs[target] = {
-                    raw: 'COUNT(distinct "' + arg + '") as ' + target
+                    raw: 'COUNT(distinct ' + arg + ') as ' + target
                 };
                 continue;
             }
@@ -166,7 +181,8 @@ var optimizer = {
             };
         }
 
-        var empty_result = _.object(reduce.exprs.map(_empty_reducer_result));
+        var expect_empty_result = _.object(reduce.exprs.map(_expected_empty_reducer_result));
+        var empty_result = _empty_reducer_result(aggrs);
 
         if (graph.node_has_option(reduce, 'every')) {
             every = graph.node_get_option(reduce, 'every');
@@ -187,7 +203,8 @@ var optimizer = {
             groupby: groupby,
             reduce_every: every,
             reduce_on: on,
-            empty_aggregate: empty_result
+            empty_aggregate: empty_result,
+            expect_empty_aggregate: expect_empty_result
         });
 
         logger.debug('optimization succeeded', JSON.stringify(optimization_info, null, 2));

--- a/lib/read.js
+++ b/lib/read.js
@@ -131,6 +131,7 @@ class ReadSql extends AdapterRead {
                 if (optimization_info.reduce_every) {
                     if (self.aggregation_targets.length > 0) {
                         self.empty_aggregate = optimization_info.empty_aggregate;
+                        self.expect_empty_aggregate = optimization_info.expect_empty_aggregate;
                         self.bufferEmptyAggregates = [];
                     }
                 }
@@ -389,9 +390,11 @@ class ReadSql extends AdapterRead {
 
     //handle trailing and leading null aggreates
     handleNullAggregates(points) {
-        if (_.isMatch(points[0], this.empty_aggregate)) {
+        var point = points[0];
+        if (_.isMatch(point, this.empty_aggregate)) {
             if (this.total_emitted_points > 0) {
-                this.bufferEmptyAggregates.push(points[0]);
+                _.extend(point, this.expect_empty_aggregate);
+                this.bufferEmptyAggregates.push(point);
             }
             return [];
         } else if (this.bufferEmptyAggregates.length > 0) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -188,6 +188,9 @@ var TestUtils = {
             var k, v;
             for (k in pt) {
                 v = pt[k];
+                if (v === Infinity || v === -Infinity) {
+                    pt[k] = null;
+                }
                 if (_.isNumber(v) && (v % 1)) {
                     pt[k] = Math.round(v * 10000) / 10000;
                 }
@@ -233,6 +236,13 @@ var TestUtils = {
         }).then(function(res) {
             expect(res.opt.errors[0]).to.equal(undefined);
             expect(res.opt.warnings[0]).to.equal(undefined);
+
+            if (params.optimize_param) {
+                var res_opt_param = res.opt.prog.graph.params.optimization_info;
+                res_opt_param = _.omit(res_opt_param, 'empty_aggregate', 'expect_empty_aggregate');
+                expect(res_opt_param)
+                    .to.deep.equal(params.optimize_param);
+            }
 
             var unopt = TestUtils.massage(res.unopt.sinks.table, params.massage);
             var opt = TestUtils.massage(res.opt.sinks.table, params.massage);


### PR DESCRIPTION
As I was working on ensuring optimization tests were actually optimizing: https://github.com/juttle/juttle-sql-adapter-common/issues/29, I found that this bug was still occuring: https://github.com/juttle/juttle-postgres-adapter/issues/16.

So I fixed it by using 2 objects:
1. What empty points should look like coming from knex.
2. What empty points would have looked like if we used juttle to perform the aggregation.

The reason the test to check empty aggregates was failing: count_unique was misspelled in the allowable aggregates.