### PR TITLE
paginate using read scheduler

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -10,6 +10,7 @@ var AdapterRead = require('juttle/lib/runtime/adapter-read');
 var errors = require('juttle/lib/errors');
 
 const ALLOWED_OPTIONS = AdapterRead.commonOptions.concat(['table', 'raw', 'debug', 'fetchSize', 'optimize']);
+const BATCHING_CONCURRENCY = 3;
 
 class ReadSql extends AdapterRead {
 
@@ -236,14 +237,20 @@ class ReadSql extends AdapterRead {
         var timeField = this.timeField || 'time';
         var buckets = this.getBatchBuckets(from, to);
 
-        return Promise.mapSeries(buckets.slice(1), (bucket, i, len) => {
+        return Promise.map(buckets, (bucket, i, len) => {
+            var start = bucket;
+            var end = buckets[i + 1];
+            if (!end) {
+                return [];
+            }
+
             var query = original_query.clone();
-            query = query.where(timeField, '>=', new Date(buckets[i].valueOf()));
-            query = query.where(timeField, '<', new Date(bucket.valueOf()));
+            query = query.where(timeField, '>=', new Date(start.valueOf()));
+            query = query.where(timeField, '<', new Date(end.valueOf()));
 
             var additionalFields = {};
             bucket.epsilon = true;
-            additionalFields[timeField] = bucket;
+            additionalFields[timeField] = end;
 
             return query.then((points) => {
                 _.each(points, function(pt) {
@@ -251,10 +258,10 @@ class ReadSql extends AdapterRead {
                 });
                 return this.formatPoints(points);
             });
-        })
+        }, { concurrency: BATCHING_CONCURRENCY })
         .then((res) => {
             return {
-                points: _.flatten(res),
+                points: _.sortBy(_.flatten(res), 'time'),
                 readEnd: to
             };
         });

--- a/lib/read.js
+++ b/lib/read.js
@@ -28,6 +28,7 @@ class ReadSql extends AdapterRead {
         this.total_emitted_points = 0;
         this.maxSize = Infinity;
         this.queueSize = Infinity;
+        this.offsetCount = 0;
 
         this.toRaw = this.baseQuery.raw;
 
@@ -42,7 +43,7 @@ class ReadSql extends AdapterRead {
 
         this.addOptimizations(params.optimization_info);
 
-        this.baseQuery = this.baseQuery.from(options.table).limit(this.getNextLimit());
+        this.baseQuery = this.baseQuery.from(options.table);
 
         if (this.timeField && this.optimization_info.type !== 'reduce') {
             this.baseQuery = this.baseQuery.orderBy(this.timeField, this.tailOptimized ? 'desc' : 'asc');
@@ -139,11 +140,131 @@ class ReadSql extends AdapterRead {
         }
     }
 
-    getBatchBuckets(optimization_info, query_start, query_end) {
+    getNextLimit() {
+        return Math.min(this.fetchSize, this.queueSize, this.maxSize - this.total_emitted_points);
+    }
+
+    //Query execution
+
+    read(from, to, limit, state) {
+        var queryExecutionPromise;
+
+        this.queueSize = limit;
+
+        if (this.raw) {
+            queryExecutionPromise = this.getRawResult();
+        } else {
+            var query = this.getPaginationQuery(from, to);
+
+            if (this.debugOption) {
+                queryExecutionPromise = this.handleDebug(query);
+            } else if (this.optimization_info.reduce_every) {
+                queryExecutionPromise = this.getReduceEveryResults(query, from, to);
+            } else {
+                queryExecutionPromise = this.executeQuery(query, to);
+            }
+        }
+
+        return queryExecutionPromise
+        .catch((err) => {
+            if (/Pool (is|was) destroyed/.test(err.message)) {
+                var connectionInfo = this.baseQuery.client.connectionSettings;
+                throw errors.runtimeError('RT-INTERNAL-ERROR', {
+                    error: 'could not connect to database: ' + JSON.stringify(connectionInfo)
+                });
+            } else {
+                throw err;
+            }
+        });
+    }
+
+    // raw query
+
+    getRawResult() {
+        return this.baseQuery
+        .then((res) => {
+            return this.handleRawResponse(res);
+        })
+        .then((points) => {
+            return {
+                points: this.formatPoints(points),
+                readEnd: new JuttleMoment(Infinity)
+            };
+        });
+    }
+
+    //the raw query response format can be different based on client
+    handleRawResponse(points) {
+        return points;
+    }
+
+    getPaginationQuery(from, to) {
+        var query = this.baseQuery.clone();
+
+        query = query.limit(this.getNextLimit());
+
+        if (this.timeField) {
+            if (from) {
+                query = query.where(this.timeField, '>=', new Date(from.valueOf()));
+                this.logger.debug('start time', new Date(from.valueOf()).toISOString());
+            }
+            if (to) {
+                query = query.where(this.timeField, '<', new Date(to.valueOf()));
+                this.logger.debug('end time', new Date(to.valueOf()).toISOString());
+            }
+        } else {
+            query = query.offset(this.offsetCount);
+        }
+        return query;
+    }
+
+    // debug option handler
+
+    handleDebug(query) {
+        this.logger.debug('returning query string as point');
+        return Promise.try(() => {
+            return  {
+                points: [{ query: query.toString() }],
+                readEnd: new JuttleMoment(Infinity)
+            };
+        });
+    }
+
+    // "reduce -every" batch query
+
+    getReduceEveryResults(original_query, from, to) {
+        var timeField = this.timeField || 'time';
+        var buckets = this.getBatchBuckets(from, to);
+
+        return Promise.mapSeries(buckets.slice(1), (bucket, i, len) => {
+            var query = original_query.clone();
+            query = query.where(timeField, '>=', new Date(buckets[i].valueOf()));
+            query = query.where(timeField, '<', new Date(bucket.valueOf()));
+
+            var additionalFields = {};
+            bucket.epsilon = true;
+            additionalFields[timeField] = bucket;
+
+            return query.then((points) => {
+                _.each(points, function(pt) {
+                    _.extend(pt, additionalFields);
+                });
+                return this.formatPoints(points);
+            });
+        })
+        .then((res) => {
+            return {
+                points: _.flatten(res),
+                readEnd: to
+            };
+        });
+    }
+
+    getBatchBuckets(query_start, query_end) {
         var self = this;
 
-        var reduce_every = optimization_info.reduce_every;
-        var reduce_on = optimization_info.reduce_on;
+        var reduce_every = this.optimization_info.reduce_every;
+        var reduce_on = this.optimization_info.reduce_on;
 
         function get_batch_offset_as_duration(every_duration) {
             try {
@@ -189,137 +310,51 @@ class ReadSql extends AdapterRead {
             });
             return buckets;
         }
-        this.batchBuckets = get_buckets();
+        return get_buckets();
     }
 
-    getNextLimit() {
-        return Math.min(this.fetchSize, this.queueSize, this.maxSize - this.total_emitted_points);
-    }
+    // query execution for timed/offset pagination
 
-    //Query execution
-
-    read(from, to, limit, state) {
-        var queryExecutionPromise;
-
-        this.queueSize = limit;
-
-        if (this.raw) {
-            queryExecutionPromise = this.baseQuery
-            .then((res) => {
-                return this.handleRawResponse(res);
-            })
-            .then((points) => {
-                return this.formatAndBuffer(points);
-            });
-        } else {
-            var query = this.baseQuery.clone();
-            if (this.timeField) {
-                if (from) {
-                    query = query.where(this.timeField, '>=', new Date(from.valueOf()));
-                    this.logger.debug('start time', new Date(from.valueOf()).toISOString());
-                }
-                if (to) {
-                    query = query.where(this.timeField, '<', new Date(to.valueOf()));
-                    this.logger.debug('end time', new Date(to.valueOf()).toISOString());
-                }
-            }
-
-            if (this.debugOption) {
-                queryExecutionPromise = Promise.try(() => { return this.handleDebug(query); });
-            } else if (this.optimization_info.reduce_every) {
-                this.getBatchBuckets(this.optimization_info, from, to);
-                queryExecutionPromise = this.paginateBuckets(query);
-            } else {
-                this.offsetCount = 0;
-                queryExecutionPromise = this.paginate(query);
-            }
-        }
-
-        return queryExecutionPromise
-        .catch(err => {
-            if (/Pool (is|was) destroyed/.test(err.message)) {
-                var connectionInfo = this.baseQuery.client.connectionSettings;
-                this.trigger('error', errors.runtimeError('RT-INTERNAL-ERROR', {
-                    error: 'could not connect to database: ' + JSON.stringify(connectionInfo)
-                }));
-            } else {
-                this.trigger('error', err);
-            }
-        })
-        .then(() => {
-            var points = this.pointsBuffer;
-            this.pointsBuffer = [];
-            return {
-                points: points,
-                readEnd: this.timeField && !this.debugOption ? to : new JuttleMoment(Infinity)
-            };
-        });
-    }
-
-    paginateBuckets(original_query) {
-        var self = this;
-        var timeField = self.timeField || 'time';
-        var buckets = self.batchBuckets;
-        return Promise.mapSeries(buckets.slice(1), function(bucket, i, len) {
-            var query = original_query.clone();
-            query = query.where(timeField, '>=', new Date(buckets[i].valueOf()));
-            query = query.where(timeField, '<', new Date(bucket.valueOf()));
-
-            var additionalFields = {};
-            bucket.epsilon = true;
-            additionalFields[timeField] = bucket;
-
-            return self.paginate(query, additionalFields);
-        });
-    }
-
-    //the raw query response format can be different based on client
-    handleRawResponse(points) {
-        return points;
-    }
-
-    paginate(query, additionalFields) {
-        this.logger.debug('executing paginated query');
+    executeQuery(query, to) {
+        this.logger.debug('executing query', query.toString());
 
         return query.then((points) => {
-            var nextQuery;
-
-            if (additionalFields) {
-                _.each(points, function(pt) {
-                    _.extend(pt, additionalFields);
-                });
-            }
             if (points.length < this.fetchSize) {
                 //no more pagination necessary
-                return this.formatAndBuffer(points);
+                return {
+                    points: points,
+                    readEnd: this.timeField ? to : new JuttleMoment(Infinity)
+                };
             }
-
             //perform time-based pagination if timeField is indicated
             if (this.timeField) {
-                nextQuery = this.processPaginatedResults(query, points, this.timeField);
-            } else {
-                this.formatAndBuffer(points);
-                this.offsetCount += points.length;
-                this.logger.debug('next pagination based on offset ', this.offsetCount);
-                nextQuery = query.offset(this.offsetCount).limit(this.getNextLimit());
+                var res = this.processPaginatedResults(points, this.timeField);
+                res.readEnd = new JuttleMoment({rawDate: new Date(res.borderValue)});
+                return res;
             }
 
-            if (nextQuery && this.getNextLimit() > 0) {
-                return this.paginate(nextQuery);
-            }
+            //offset pagination
+            this.offsetCount += points.length;
+            return {
+                points: points,
+                readEnd: null //read again
+            };
+        })
+        .then((res) => {
+            res.points = this.formatPoints(res.points);
+            return res;
         });
     }
 
     // utility function to help with pagination:
     //      - pass in an page of sorted results and specify the sort field
-    //      - returns paginated query
-    processPaginatedResults(query, resultsPage, sortField) {
+    //      - returns formatted points used and border value
+    processPaginatedResults(resultsPage, sortField) {
         var nonBorderPoints = [];
         var len = resultsPage.length;
         var borderValue = _.last(resultsPage)[sortField];
         if (!borderValue) {
-            this.trigger('error', new Error(`value of field "${sortField}" is ${typeof borderValue}`));
-            return;
+            throw new Error(`value of field "${sortField}" is ${typeof borderValue}`);
         }
 
         for (var i = len - 2; i >= 0 ; i--) {
@@ -330,24 +365,19 @@ class ReadSql extends AdapterRead {
             }
         }
         if (nonBorderPoints.length === 0) {
-            this.trigger('error', new Error(
+            throw new Error(
                 `unable to paginate because all of fetchSize ` +
-                `${this.fetchSize} has the same timeField. Consider increasing fetchSize.`
-            ));
-            return;
+                `${this.fetchSize} has the same ${sortField}. Consider increasing fetchSize.`
+            );
         }
 
-        this.formatAndBuffer(nonBorderPoints);
-
-        this.logger.debug('next pagination based on timefield ', sortField, ' with border value ', borderValue);
-        return query.where(sortField, this.tailOptimized ? '<=' : '>=', new Date(borderValue));
+        return {
+            points: nonBorderPoints,
+            borderValue: borderValue
+        };
     }
 
-    formatAndBuffer(points) {
-        var formattedPoints = this.formatPoints(points);
-        this.total_emitted_points += formattedPoints.length;
-        this.pointsBuffer = this.pointsBuffer.concat(formattedPoints);
-    }
+    // shared code between all query types
 
     formatPoints(points) {
         if (this.addPointFormatting) {
@@ -370,6 +400,7 @@ class ReadSql extends AdapterRead {
             points = this.parseTime(points, this.timeField);
         }
 
+        this.total_emitted_points += points.length;
         return points;
     }
 
@@ -402,13 +433,6 @@ class ReadSql extends AdapterRead {
             this.bufferEmptyAggregates = [];
         }
         return points;
-    }
-
-    handleDebug() {
-        this.logger.debug('returning query string as point');
-        this.pointsBuffer = [{
-            query: this.baseQuery.toString()
-        }];
     }
 }
 

--- a/test/optimize.spec.js
+++ b/test/optimize.spec.js
@@ -105,7 +105,7 @@ describe('test optimizations', function() {
             expect(result.sinks.table).to.have.length(5);
         })
         .then(function(result) {
-            return check_optimization_juttle({
+            return check_success({
                 program: 'read sql -debug true -to :yesterday: -fetchSize 2 -timeField "time" -table "logs" level = "info" | tail 5'
             });
         })

--- a/test/time.spec.js
+++ b/test/time.spec.js
@@ -76,9 +76,8 @@ describe('test time usage', function () {
             program: 'read sql -fetchSize 100 -from :200 days ago: -timeField "create_time" -table "logs_same_time"'
         })
         .then(function(result) {
-            expect(result.errors).to.have.length(1);
             expect(result.errors[0])
-                .to.match(/.*unable to paginate because all of fetchSize 100 has the same timeField.*/);
+                .to.match(/.*unable to paginate because all of fetchSize 100 has the same create_time.*/);
         });
     });
     it('sql time usage with same timeField without pagination', function() {

--- a/test/time.spec.js
+++ b/test/time.spec.js
@@ -13,7 +13,7 @@ describe('test time usage', function () {
 
     it('sql time usage', function() {
         return check_success({
-            program: 'read sql -from :100 days ago: -to :now: -table "logs" | reduce -every :3 days: avg = avg(code)'
+            program: 'read sql -from :100 days ago: -to :1 day ago: -table "logs" | reduce -every :3 days: avg = avg(code)'
         })
         .then(function(result) {
             //catch single element reduce output


### PR DESCRIPTION
1. Paginate through time and offset using read scheduler.
2. Take out buffer in favor of always returning points from query.
3. Break read function into smaller functions.
4. throw instead of triggering errors in pagination code.
5. fix bug https://github.com/juttle/juttle-sqlite-adapter/issues/5
6. resolves issue: https://github.com/juttle/juttle-sql-adapter-common/issues/25

This is what I mentioned in standup today: https://github.com/juttle/juttle-sqlite-adapter/issues/5. @demmer asked about what was really happening in this issue so here is an explanation:

As we paginated through data sorted by time our query string would increase in size like so:
`read sql -fetchSize 10 -from :150 days ago: -to :1 days ago:`

```
executing paginated query select * from "logs" where "time" >= '2015-09-14 01:25:48.113' and "time" < '2016-02-10 00:25:48.113' and "time" >= '2015-09-24 00:25:47.520' and "time" >= '2015-10-03 00:25:47.520' and "time" >= '2015-10-12 00:25:47.520' and "time" >= '2015-10-21 00:25:47.520' and "time" >= '2015-10-30 00:25:47.520' and "time" >= '2015-11-08 00:25:47.521' and "time" >= '2015-11-17 00:25:47.521' and "time" >= '2015-11-26 00:25:47.521' and "time" >= '2015-12-05 00:25:47.521' and "time" >= '2015-12-14 00:25:47.521' and "time" >= '2015-12-23 00:25:47.521' and "time" >= '2016-01-01 00:25:47.521' and "time" >= '2016-01-10 00:25:47.521' and "time" >= '2016-01-19 00:25:47.521' and "time" >= '2016-01-28 00:25:47.521' and "time" >= '2016-02-06 00:25:47.521' order by "time" asc limit 10
```

To simply fix the bug all I needed to do was `query.clone()` before setting time ranges but I thought since I was going to work on this I would also paginate using read scheduler.

I'm pretty excited about the new read code - check it out.