### PR TITLE
ensure from or to are set if timeField

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -79,6 +79,12 @@ class ReadSql extends AdapterRead {
                 proc: 'read-sql'
             });
         }
+        if (options.timeField && !options.from && !options.to) {
+            throw new errors.runtimeError('RT-MISSING-OPTION-ERROR', {
+                option: '-from, -to, or -last when -timeField is specified',
+                proc: 'read-sql'
+            });
+        }
     }
 
     setOptions(options) {

--- a/test/optimize.spec.js
+++ b/test/optimize.spec.js
@@ -60,7 +60,7 @@ describe('test optimizations', function() {
     });
     it('tail with positive number shows initial limit of 5 in query', function() {
         return check_success({
-            program: 'read sql -debug true -timeField "time" -table "logs" level = "info" | tail 5'
+            program: 'read sql -debug true -last :200 days: -timeField "time" -table "logs" level = "info" | tail 5'
         })
         .then(function(result) {
             expect(result.sinks.table).to.have.length(1);

--- a/test/time.spec.js
+++ b/test/time.spec.js
@@ -80,6 +80,17 @@ describe('test time usage', function () {
                 .to.match(/.*unable to paginate because all of fetchSize 100 has the same create_time.*/);
         });
     });
+    it('sql with timeField but no to/from', function() {
+        return check_juttle({
+            program: 'read sql -timeField "time" -table "logs"'
+        })
+        .then(function() {
+            throw new Error('We should not get this error');
+        })
+        .catch(function(result) {
+            expect(result.message).to.contain("required option -from, -to, or -last when -timeField is specified");
+        });
+    });
     it('sql time usage with same timeField without pagination', function() {
         return check_success({
             program: 'read sql -from :200 days ago: -timeField "create_time" -table "logs_same_time"'


### PR DESCRIPTION
@mstemm ran into https://github.com/juttle/juttle-sql-adapter-common/issues/42 when working on demo stuff.

Lets insure a proper error is thrown when no `to` or `from` indicated but `timeField` is. 

