### PR TITLE
dynamically change config through options

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,7 @@ function SqlAdapter(config) {
         name: 'sql',
         read: require('./lib/read'),
         write: require('./lib/write'),
-        optimizer: require('./lib/optimize'),
-        knex: db.getDbConnection()
+        optimizer: require('./lib/optimize')
     };
 }
 module.exports = SqlAdapter;

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,18 +1,43 @@
 var logger = require('juttle/lib/logger').getLogger('sql-db-init');
-
+var _ = require('underscore');
 var knex;
+var savedDbId;
+var confArr;
 
 var DB = {
     init: function(config) {
-        if (config.knex) {
-            knex = config.knex;
+        confArr = _.isArray(config) ? config : [config];
+    },
+
+    getDbConnection: function (options) {
+        options = options || {};
+
+        var dbid = `${options.id}-${options.db}`;
+        if (knex && dbid === savedDbId) {
+            return knex;
+        }
+
+        var conf = _.findWhere(confArr, {id: options.id}) || confArr[0];
+        knex = DB.getKnex(conf, options);
+        savedDbId = dbid;
+
+        if (knex.client) {
             logger.info('initializing db connection with conf:', knex.client.config);
         } else {
-            throw new Error('knex config for sql adapter not found.');
+            throw new Error('knex config for sql adapter not found:' + JSON.stringify(options));
         }
-    },
-    getDbConnection: function () {
         return knex;
+    },
+
+    getKnex: function(config, options) {
+        throw new Error('getKnex function not implemented by adapter');
+    },
+
+    closeConnection: function() {
+        if (knex) {
+            knex.destroy();
+            knex = null;
+        }
     }
 };
 

--- a/lib/read.js
+++ b/lib/read.js
@@ -9,7 +9,7 @@ var Promise = require('bluebird');
 var AdapterRead = require('juttle/lib/runtime/adapter-read');
 var errors = require('juttle/lib/errors');
 
-const ALLOWED_OPTIONS = AdapterRead.commonOptions.concat(['table', 'raw', 'debug', 'fetchSize', 'optimize']);
+const ALLOWED_OPTIONS = AdapterRead.commonOptions.concat(['table', 'raw', 'debug', 'fetchSize', 'optimize', 'db', 'id']);
 const BATCHING_CONCURRENCY = 3;
 
 class ReadSql extends AdapterRead {
@@ -24,7 +24,7 @@ class ReadSql extends AdapterRead {
         this.setOptions(options);
 
         this.pointsBuffer = [];
-        this.baseQuery = db.getDbConnection();
+        this.baseQuery = db.getDbConnection(_.pick(options, 'db', 'id'));
 
         this.total_emitted_points = 0;
         this.maxSize = Infinity;

--- a/lib/write.js
+++ b/lib/write.js
@@ -8,12 +8,13 @@ var values = require('juttle/lib/runtime/values');
 var Promise = require('bluebird');
 var logger = require('juttle/lib/logger').getLogger('sql-db-write');
 
-const ALLOWED_OPTIONS = ['table'];
+const ALLOWED_OPTIONS = ['table', 'db', 'id'];
 
 class WriteSql extends AdapterWrite {
     constructor(options, params) {
         super(options, params);
         this.handleOptions(options);
+        this.knex = db.getDbConnection(_.pick(options, 'db', 'id'));
         this.inserts_in_progress = 0;
         this.eof_received = false;
         this.writePromise = Promise.resolve();
@@ -46,6 +47,14 @@ class WriteSql extends AdapterWrite {
         this.writePromise = this.writePromise.then(() => {
             var formattedPoints = this.formatPoints(points);
             return this.insertPoints(formattedPoints);
+        }).catch((err) => {
+            if (/Pool (is|was) destroyed/.test(err.message)) {
+                var connectionInfo = this.knex.client.connectionSettings;
+                err = errors.runtimeError('RT-INTERNAL-ERROR', {
+                    error: 'could not connect to database: ' + JSON.stringify(connectionInfo)
+                });
+            }
+            this.trigger('error', err);
         });
     }
 
@@ -78,15 +87,8 @@ class WriteSql extends AdapterWrite {
     insertPoints(points) {
         if (points.length === 0) { return; }
 
-        var knex = db.getDbConnection();
-
         //XXX splice is a temporary fix until we have shared concurrency handling logic
-        return knex(this.table).insert(points.splice(0, 1000))
-        .catch((err) => {
-            this.trigger('error', new errors.runtimeError('RT-INTERNAL-ERROR', {
-                error: err.toString()
-            }));
-        })
+        return this.knex(this.table).insert(points.splice(0, 1000))
         .then(() => {
             return this.insertPoints(points);
         });

--- a/test/db.spec.js
+++ b/test/db.spec.js
@@ -3,24 +3,23 @@ var TestUtils = require("./utils");
 var check_juttle = TestUtils.check_sql_juttle;
 
 describe('test db connection error', function () {
-    before(function() {
-        return TestUtils.clearState()
-        .then(function() {
-            return TestUtils.init(true);
-        });
-    });
-    after(function() {
-        return TestUtils.clearState()
-        .then(function() {
-            TestUtils.init();
-        });
-    });
-    it('error on incorrect connection string or credentials', function() {
+    it('incorrect connection string or credentials', function() {
         return check_juttle({
-            program: 'read sql -table "fake"'
+            program: 'read sql -id "fake" -table "fake"'
         })
         .then(function(result) {
             expect(result.errors[0]).to.contain('could not connect to database');
+            expect(result.errors[0]).to.contain('should_not_work');
+        });
+    });
+    it('choose db with option', function() {
+        var fake_db_name = "./fake/database";
+        return check_juttle({
+            program: `read sql -db "${fake_db_name}" -raw "SELECT * FROM hello"`
+        })
+        .then(function(result) {
+            expect(result.errors[0]).to.contain('could not connect to database');
+            expect(result.errors[0]).to.match(/(db|filename|database)":".\/fake\/database"/);
         });
     });
 });

--- a/test/write.spec.js
+++ b/test/write.spec.js
@@ -58,4 +58,13 @@ describe('write proc', function () {
             expect(result.errors[0]).to.match(/(has no column|column .* does not exist|Unknown column 'c')/);
         });
     });
+
+    it('write to dynamic db', function() {
+        return check_juttle({
+            program: 'emit -limit 1 | put c = "hi" | put d = "yes" | write sql -db "./nosuchdir/nosuchdb" -table "sqlwriter"'
+        })
+        .then(function(result) {
+            expect(result.errors[0]).to.contain("could not connect to database");
+        });
+    });
 });


### PR DESCRIPTION
1. Allow configuration to be an array with `id`s.
2. Allow option `id` in order to select the appropriate config object from a config array.
3. Allow option `db` to select a database name dynamically when running a program (read or write).

(I did need to take out aggregate query parallelization because it was buggy - nothing to do with the current config code: https://github.com/juttle/juttle-sql-adapter-common/issues/45) I'll fix that soon.

fixes https://github.com/juttle/juttle-sql-adapter-common/issues/38
Will be easy to do https://github.com/juttle/juttle-sqlite-adapter/issues/3 right after.

The postgres code that goes on top of this: https://github.com/juttle/juttle-postgres-adapter/pull/22

By +1ing this you're also +1ing the postgres code