### PR TITLE
Juttle5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ addons:
 
 before_install:
     - export CXX="g++-4.8"
-    - npm install juttle@^0.4.0
 
 node_js:
     - '4.2'
-    - '5.0'
+
+before_script:
+    - npm install juttle@^0.5.0
 
 script:
-    - npm test
     - npm run test-coverage
     - npm run check-coverage

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/juttle/juttle-sql-adapter-common.svg?branch=master)](https://travis-ci.org/juttle/juttle-sql-adapter-common)
 
-Common code shared among
+Code from the `/lib` and `/test` directory shared among
 [PostgreSQL](https://github.com/juttle/juttle-postgres-adapter/),
 [MySQL](https://github.com/juttle/juttle-mysql-adapter/)
 and [SQLite](https://github.com/juttle/juttle-sqlite-adapter/) adapters.

--- a/index.js
+++ b/index.js
@@ -1,18 +1,32 @@
 /*
     SQL Adapter Common Code
-    Plug in your favorite knex-supported RDBMS and use juttle to interact with it.
+    Note: This file is only used for testing.
 */
 'use strict';
 
-let db = require('./lib/db');
+let db = require('./sqlite-db');
+let Read = require('./lib/read');
+let Write = require('./lib/write');
+
+class SqliteRead extends Read {
+    getDbConnection(options) {
+        return db.getDbConnection(options);
+    }
+}
+
+class SqliteWrite extends Write {
+    getDbConnection(options) {
+        return db.getDbConnection(options);
+    }
+}
 
 function SqlAdapter(config) {
     db.init(config);
 
     return {
         name: 'sql',
-        read: require('./lib/read'),
-        write: require('./lib/write'),
+        read: SqliteRead,
+        write: SqliteWrite,
         optimizer: require('./lib/optimize')
     };
 }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,9 @@
     SQL Adapter Common Code
     Plug in your favorite knex-supported RDBMS and use juttle to interact with it.
 */
-var db = require('./lib/db');
+'use strict';
+
+let db = require('./lib/db');
 
 function SqlAdapter(config) {
     db.init(config);

--- a/lib/db.js
+++ b/lib/db.js
@@ -27,15 +27,17 @@ class DB {
         //ensure that no changes are permanently made to the config in getKnex function.
         conf = _.clone(conf);
 
-        knex = this.getKnex(conf, options);
-        savedDbId = dbid;
+        let newKnex = this.getKnex(conf, options);
 
-        if (knex.client) {
-            logger.info('initializing db connection with conf:', knex.client.config);
+        if (newKnex.client) {
+            logger.info('initializing db connection with conf:', newKnex.client.config);
         } else {
-            knex = null;
             throw new Error('knex config for sql adapter not found:' + JSON.stringify(options));
         }
+
+        savedDbId = dbid;
+        knex = newKnex;
+
         return knex;
     }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,4 +1,6 @@
-var logger = require('juttle/lib/logger').getLogger('sql-db-init');
+/* global JuttleAdapterAPI */
+var logger = JuttleAdapterAPI.getLogger('sql-db-init');
+
 var _ = require('underscore');
 var knex;
 var savedDbId;
@@ -18,12 +20,17 @@ var DB = {
         }
 
         var conf = _.findWhere(confArr, {id: options.id}) || confArr[0];
+
+        //ensure that no changes are permanently made to the config in getKnex function.
+        conf = _.clone(conf);
+
         knex = DB.getKnex(conf, options);
         savedDbId = dbid;
 
         if (knex.client) {
             logger.info('initializing db connection with conf:', knex.client.config);
         } else {
+            knex = null;
             throw new Error('knex config for sql adapter not found:' + JSON.stringify(options));
         }
         return knex;

--- a/lib/db.js
+++ b/lib/db.js
@@ -27,7 +27,7 @@ class DB {
         //ensure that no changes are permanently made to the config in getKnex function.
         conf = _.clone(conf);
 
-        knex = DB.getKnex(conf, options);
+        knex = this.getKnex(conf, options);
         savedDbId = dbid;
 
         if (knex.client) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,25 +1,28 @@
+'use strict';
+
 /* global JuttleAdapterAPI */
-var logger = JuttleAdapterAPI.getLogger('sql-db-init');
+let logger = JuttleAdapterAPI.getLogger('sql-db-init');
 
-var _ = require('underscore');
-var knex;
-var savedDbId;
-var confArr;
+let _ = require('underscore');
 
-var DB = {
-    init: function(config) {
+let knex;
+let savedDbId;
+let confArr;
+
+class DB {
+    static init(config) {
         confArr = _.isArray(config) ? config : [config];
-    },
+    }
 
-    getDbConnection: function (options) {
+    static getDbConnection(options) {
         options = options || {};
 
-        var dbid = `${options.id}-${options.db}`;
+        let dbid = `${options.id}-${options.db}`;
         if (knex && dbid === savedDbId) {
             return knex;
         }
 
-        var conf = _.findWhere(confArr, {id: options.id}) || confArr[0];
+        let conf = _.findWhere(confArr, {id: options.id}) || confArr[0];
 
         //ensure that no changes are permanently made to the config in getKnex function.
         conf = _.clone(conf);
@@ -34,18 +37,18 @@ var DB = {
             throw new Error('knex config for sql adapter not found:' + JSON.stringify(options));
         }
         return knex;
-    },
+    }
 
-    getKnex: function(config, options) {
+    static getKnex(config, options) {
         throw new Error('getKnex function not implemented by adapter');
-    },
+    }
 
-    closeConnection: function() {
+    static closeConnection() {
         if (knex) {
             knex.destroy();
             knex = null;
         }
     }
-};
+}
 
 module.exports = DB;

--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* global JuttleAdapterAPI */
-var reducerDefaultValue = JuttleAdapterAPI.runtime.reducerDefaultValue;
+let reducerDefaultValue = JuttleAdapterAPI.runtime.reducerDefaultValue;
 let logger = JuttleAdapterAPI.getLogger('sql-db-write');
 
 let _ = require('underscore');
@@ -31,7 +31,7 @@ function _expected_empty_reducer_result(expr) {
 }
 
 function _empty_reducer_result(aggrs) {
-    var empty_result = {};
+    let empty_result = {};
     _.each(aggrs, function(val, target) {
         empty_result[target] = EMPTY_AGGREGATE_VALS[val.name || 'count_unique'];
     });
@@ -61,15 +61,15 @@ function reduce_expr_is_optimizable(expr) {
     return true;
 }
 
-var optimizer = {
-    optimize_head: function(read, head, graph, optimization_info) {
+class Optimizer {
+    static optimize_head(read, head, graph, optimization_info) {
         if (optimization_info.type && optimization_info.type !== 'head') {
             logger.debug('optimization aborting -- cannot append head optimization to prior',
                 optimization_info.type, 'optimization');
             return false;
         }
 
-        var limit = graph.node_get_option(head, 'arg');
+        let limit = graph.node_get_option(head, 'arg');
 
         if (optimization_info.hasOwnProperty('limit')) {
             limit = Math.min(limit, optimization_info.limit);
@@ -78,20 +78,21 @@ var optimizer = {
         optimization_info.type = 'head';
         optimization_info.limit = limit;
         return true;
-    },
-    optimize_tail: function(read, tail, graph, optimization_info) {
+    }
+
+    static optimize_tail(read, tail, graph, optimization_info) {
         if (optimization_info.type && optimization_info.type !== 'tail') {
             logger.debug('optimization aborting -- cannot append tail optimization to prior',
                 optimization_info.type, 'optimization');
             return false;
         }
 
-        var limit = graph.node_get_option(tail, 'arg');
+        let limit = graph.node_get_option(tail, 'arg');
         if (optimization_info.hasOwnProperty('limit')) {
             limit = Math.min(limit, optimization_info.limit);
         }
 
-        var fetchSize = graph.node_get_option(read, 'fetchSize') || FETCH_SIZE_LIMIT;
+        let fetchSize = graph.node_get_option(read, 'fetchSize') || FETCH_SIZE_LIMIT;
         if (fetchSize < limit) {
             // Doesn't make sense to reverse multiple pages of results in the adapter.
             logger.debug('optimization aborting -- fetchSize cannot be less than tail limit', {
@@ -104,8 +105,9 @@ var optimizer = {
         optimization_info.type = 'tail';
         optimization_info.limit = limit;
         return true;
-    },
-    optimize_reduce: function(read, reduce, graph, optimization_info) {
+    }
+
+    static optimize_reduce(read, reduce, graph, optimization_info) {
         if (!graph.node_contains_only_options(reduce, ALLOWED_REDUCE_OPTIONS)) {
             logger.warn('optimization aborting -- cannot optimize reduce with options', graph.node_get_option_names(reduce));
             return false;
@@ -114,31 +116,31 @@ var optimizer = {
             logger.debug('optimization aborting -- cannot append reduce optimization to prior', optimization_info.type, 'optimization');
             return false;
         }
-        var groupby = graph.node_get_option(reduce, 'groupby');
-        var grouped = groupby && groupby.length > 0;
+        let groupby = graph.node_get_option(reduce, 'groupby');
+        let grouped = groupby && groupby.length > 0;
         if (grouped && groupby.indexOf('time') !== -1) {
             logger.debug('optimization aborting -- cannot optimize group by time');
             return false;
         }
 
-        var forget = graph.node_get_option(reduce, 'forget');
+        let forget = graph.node_get_option(reduce, 'forget');
         if (forget === false) {
             logger.debug('optimization aborting -- cannot optimize -forget false');
             return false;
         }
 
-        var aggrs = {},
+        let aggrs = {},
             on,
             every;
 
-        for (var i = 0; i < reduce.exprs.length; i++) { //make for-each for closure vars
-            var expr = reduce.exprs[i];
+        for (let i = 0; i < reduce.exprs.length; i++) { //make for-each for closure lets
+            let expr = reduce.exprs[i];
             if (!reduce_expr_is_optimizable(expr)) {
                 return false;
             }
 
-            var target = _getFieldName(expr.left);
-            var reducer = _getReducerName(expr.right);
+            let target = _getFieldName(expr.left);
+            let reducer = _getReducerName(expr.right);
 
             if (reducer === 'count' && expr.right.arguments.length === 0) {
                 logger.debug('found simple count() reducer, optimizing');
@@ -154,12 +156,12 @@ var optimizer = {
                 return false;
             }
 
-            var argument_object = expr.right.arguments[0];
+            let argument_object = expr.right.arguments[0];
             if (argument_object.type !== 'StringLiteral') {
                 logger.debug('optimization aborting -- found unexpected reducer argument:', JSON.stringify(argument_object));
                 return false;
             }
-            var arg = argument_object.value;
+            let arg = argument_object.value;
 
             if (!_.contains(VALID_AGGREGATIONS, reducer)) {
                 logger.debug('optimization aborting -- unoptimizable reducer', JSON.stringify(reducer, null, 2));
@@ -180,11 +182,11 @@ var optimizer = {
         }
 
         // expected by juttle
-        var expect_empty_result = _.object(reduce.exprs.map(_expected_empty_reducer_result));
+        let expect_empty_result = _.object(reduce.exprs.map(_expected_empty_reducer_result));
 
         // Actual empty point match returned from optimized query:
         //      currently the only difference is that actual empty sum is null while expected 0.
-        var empty_result = _empty_reducer_result(aggrs);
+        let empty_result = _empty_reducer_result(aggrs);
 
         if (graph.node_has_option(reduce, 'every')) {
             every = graph.node_get_option(reduce, 'every');
@@ -213,6 +215,6 @@ var optimizer = {
 
         return true;
     }
-};
+}
 
-module.exports = optimizer;
+module.exports = Optimizer;

--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -1,11 +1,15 @@
-var logger = require('juttle/lib/logger').getLogger('sql-db-optimizer');
-var _ = require('underscore');
-var reducers = require('juttle/lib/runtime/reducers').reducers;
+'use strict';
 
-var FETCH_SIZE_LIMIT = 10000;
-var ALLOWED_REDUCE_OPTIONS = ['forget', 'groupby', 'every', 'on'];
-var VALID_AGGREGATIONS = ['count', 'avg', 'sum', 'min', 'max', 'count_unique'];
-var EMPTY_AGGREGATE_VALS = {
+/* global JuttleAdapterAPI */
+var reducerDefaultValue = JuttleAdapterAPI.runtime.reducerDefaultValue;
+let logger = JuttleAdapterAPI.getLogger('sql-db-write');
+
+let _ = require('underscore');
+
+const FETCH_SIZE_LIMIT = 10000;
+const ALLOWED_REDUCE_OPTIONS = ['forget', 'groupby', 'every', 'on'];
+const VALID_AGGREGATIONS = ['count', 'avg', 'sum', 'min', 'max', 'count_unique'];
+const EMPTY_AGGREGATE_VALS = {
     avg: null,
     min: null,
     max: null,
@@ -15,21 +19,15 @@ var EMPTY_AGGREGATE_VALS = {
 };
 
 function _getFieldName(node) {
-    return node.expression.value;
+    return node.name;
 }
 
 function _getReducerName(node) {
-    return node.name.name;
-}
-
-function _isSimpleFieldReference(node) {
-    return node.type === 'UnaryExpression' &&
-        node.operator === '*' &&
-        node.expression.type === 'StringLiteral';
+    return node.callee.name;
 }
 
 function _expected_empty_reducer_result(expr) {
-    return [_getFieldName(expr.left), reducers[_getReducerName(expr.right)].id];
+    return [_getFieldName(expr.left), reducerDefaultValue(_getReducerName(expr.right))];
 }
 
 function _empty_reducer_result(aggrs) {
@@ -41,16 +39,16 @@ function _empty_reducer_result(aggrs) {
 }
 
 function _isReducerCall(node) {
-    return (node.type === 'ReducerCall');
+    return (node.type === 'CallExpression' && node.context === 'reduce');
 }
 
 function reduce_expr_is_optimizable(expr) {
-    if (!_isSimpleFieldReference(expr.left)) {
+    if (expr.left.type !== 'Field') {
         logger.debug('optimization aborting -- unexpected reduce lhs:', expr.left);
         return false;
     }
 
-    if (expr.left.expression.value === 'time') {
+    if (expr.left.name === 'time') {
         logger.debug('optimization aborting -- cannot optimize reduce on time');
         return false;
     }

--- a/lib/read.js
+++ b/lib/read.js
@@ -3,13 +3,13 @@
 /* global JuttleAdapterAPI */
 let AdapterRead = JuttleAdapterAPI.AdapterRead;
 let JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
-var errors = JuttleAdapterAPI.errors;
+let errors = JuttleAdapterAPI.errors;
 
 let _ = require('underscore');
 let Promise = require('bluebird');
 
 let db = require('./db');
-let FilterSQLCompiler = require('./sql_filter');
+let FilterSQLCompiler = require('./sql-filter');
 
 const BATCHING_CONCURRENCY = 3;
 
@@ -95,48 +95,47 @@ class ReadSql extends AdapterRead {
     }
 
     addFilters(filter_ast) {
-        var compiler = new FilterSQLCompiler({ baseQuery: this.baseQuery });
+        let compiler = new FilterSQLCompiler({ baseQuery: this.baseQuery });
         return compiler.compile(filter_ast);
     }
 
     addOptimizations(optimization_info) {
-        var self = this;
         this.optimization_info = optimization_info || {};
 
         if (!_.isEmpty(this.optimization_info)) {
             this.logger.debug('adding optimizations: ', optimization_info);
             if (optimization_info.type === 'head' || optimization_info.type === 'tail') {
                 this.logger.debug(optimization_info.type + ' optimization, new max size: ', optimization_info.limit);
-                self.maxSize = optimization_info.limit;
-                self.tailOptimized = optimization_info.type === 'tail';
+                this.maxSize = optimization_info.limit;
+                this.tailOptimized = optimization_info.type === 'tail';
             }
             if (optimization_info.type === 'reduce') {
-                var groupby = optimization_info.groupby;
+                let groupby = optimization_info.groupby;
                 if (groupby && groupby.length > 0) {
                     this.logger.debug('adding groupby: ', groupby);
-                    self.baseQuery = self.baseQuery.select(groupby).groupBy(groupby);
+                    this.baseQuery = this.baseQuery.select(groupby).groupBy(groupby);
                 }
-                self.aggregation_targets = [];
-                _.each(optimization_info.aggregations, function(aggregation, target_field) {
-                    self.logger.debug('adding aggregation: ', {
+                this.aggregation_targets = [];
+                _.each(optimization_info.aggregations, (aggregation, target_field) => {
+                    this.logger.debug('adding aggregation: ', {
                         func: aggregation.name,
                         by_field: aggregation.field,
                         target_field: target_field
                     });
 
                     if (aggregation.raw) {
-                        self.baseQuery = self.baseQuery.select(self.toRaw(aggregation.raw));
+                        this.baseQuery = this.baseQuery.select(this.toRaw(aggregation.raw));
                     } else {
-                        self.baseQuery = self.baseQuery[aggregation.name](aggregation.field + ' as ' + target_field);
+                        this.baseQuery = this.baseQuery[aggregation.name](aggregation.field + ' as ' + target_field);
                     }
 
-                    self.aggregation_targets.push(target_field);
+                    this.aggregation_targets.push(target_field);
                 });
                 if (optimization_info.reduce_every) {
-                    if (self.aggregation_targets.length > 0) {
-                        self.empty_aggregate = optimization_info.empty_aggregate;
-                        self.expect_empty_aggregate = optimization_info.expect_empty_aggregate;
-                        self.bufferEmptyAggregates = [];
+                    if (this.aggregation_targets.length > 0) {
+                        this.empty_aggregate = optimization_info.empty_aggregate;
+                        this.expect_empty_aggregate = optimization_info.expect_empty_aggregate;
+                        this.bufferEmptyAggregates = [];
                     }
                 }
             }
@@ -157,7 +156,7 @@ class ReadSql extends AdapterRead {
                 return this.getRawResult();
             }
 
-            var query = this.getPaginationQuery(from, to);
+            let query = this.getPaginationQuery(from, to);
 
             if (this.debugOption) {
                 return this.handleDebug(query);
@@ -169,7 +168,7 @@ class ReadSql extends AdapterRead {
         })
         .catch((err) => {
             if (/Pool (is|was) destroyed/.test(err.message)) {
-                var connectionInfo = this.baseQuery.client.connectionSettings;
+                let connectionInfo = this.baseQuery.client.connectionSettings;
                 throw errors.runtimeError('INTERNAL-ERROR', {
                     error: 'could not connect to database: ' + JSON.stringify(connectionInfo)
                 });
@@ -200,7 +199,7 @@ class ReadSql extends AdapterRead {
     }
 
     getPaginationQuery(from, to) {
-        var query = this.baseQuery.clone();
+        let query = this.baseQuery.clone();
 
         query = query.limit(this.getNextLimit());
 
@@ -232,21 +231,21 @@ class ReadSql extends AdapterRead {
     // "reduce -every" batch query
 
     getReduceEveryResults(original_query, from, to) {
-        var timeField = this.timeField || 'time';
-        var buckets = this.getBatchBuckets(from, to);
+        let timeField = this.timeField || 'time';
+        let buckets = this.getBatchBuckets(from, to);
 
         return Promise.map(buckets, (bucket, i, len) => {
-            var start = bucket;
-            var end = buckets[i + 1];
+            let start = bucket;
+            let end = buckets[i + 1];
             if (!end) {
                 return [];
             }
 
-            var query = original_query.clone();
+            let query = original_query.clone();
             query = query.where(timeField, '>=', new Date(start.valueOf()));
             query = query.where(timeField, '<', new Date(end.valueOf()));
 
-            var additionalFields = {};
+            let additionalFields = {};
             bucket.epsilon = true;
             additionalFields[timeField] = end;
 
@@ -258,7 +257,7 @@ class ReadSql extends AdapterRead {
             });
         }, { concurrency: BATCHING_CONCURRENCY })
         .then((res) => {
-            var sortedPoints = _.chain(res)
+            let sortedPoints = _.chain(res)
             .flatten()
             .sortBy(timeField)
             .value();
@@ -273,10 +272,8 @@ class ReadSql extends AdapterRead {
     }
 
     getBatchBuckets(query_start, query_end) {
-        var self = this;
-
-        var reduce_every = this.optimization_info.reduce_every;
-        var reduce_on = this.optimization_info.reduce_on;
+        let reduce_every = this.optimization_info.reduce_every;
+        let reduce_on = this.optimization_info.reduce_on;
 
         function get_batch_offset_as_duration(every_duration) {
             try {
@@ -285,44 +282,42 @@ class ReadSql extends AdapterRead {
                 // translate a non-duration -on into the equivalent duration
                 // e.g. if we're doing -every :hour: -on :2015-03-16T18:32:00.000Z:
                 // then that's equivalent to -every :hour: -on :32 minutes:
-                var moment = new JuttleMoment(reduce_on);
+                let moment = new JuttleMoment(reduce_on);
                 return JuttleMoment.subtract(moment, JuttleMoment.quantize(moment, every_duration));
             }
         }
 
-        function get_buckets() {
-            var buckets = [query_start];
+        let buckets = [query_start];
 
-            var duration = JuttleMoment.duration(reduce_every);
-            var zeroth_bucket = JuttleMoment.quantize(query_start, duration);
-            var last_bucket = JuttleMoment.quantize(query_end, duration);
+        let duration = JuttleMoment.duration(reduce_every);
+        let zeroth_bucket = JuttleMoment.quantize(query_start, duration);
+        let last_bucket = JuttleMoment.quantize(query_end, duration);
 
-            if (reduce_on) {
-                var offset = get_batch_offset_as_duration(duration);
-                zeroth_bucket = JuttleMoment.add(zeroth_bucket, offset);
-                if (zeroth_bucket.gt(query_start)) {
-                    buckets.push(zeroth_bucket);
-                }
-                last_bucket = JuttleMoment.add(last_bucket, offset);
+        if (reduce_on) {
+            let offset = get_batch_offset_as_duration(duration);
+            zeroth_bucket = JuttleMoment.add(zeroth_bucket, offset);
+            if (zeroth_bucket.gt(query_start)) {
+                buckets.push(zeroth_bucket);
             }
-
-            var intermediate_bucket = JuttleMoment.add(zeroth_bucket, duration);
-
-            while (intermediate_bucket.lte(last_bucket)) {
-                buckets.push(intermediate_bucket);
-                intermediate_bucket = JuttleMoment.add(intermediate_bucket, duration);
-            }
-
-            //this replaces end_query as the final aggregation time
-            //end_query right endpoint already in the SQL where clause
-            buckets.push(intermediate_bucket);
-
-            _.each(buckets, function(b, i) {
-                self.logger.debug('time bucket ' + i, new Date(b.valueOf()).toISOString());
-            });
-            return buckets;
+            last_bucket = JuttleMoment.add(last_bucket, offset);
         }
-        return get_buckets();
+
+        let intermediate_bucket = JuttleMoment.add(zeroth_bucket, duration);
+
+        while (intermediate_bucket.lte(last_bucket)) {
+            buckets.push(intermediate_bucket);
+            intermediate_bucket = JuttleMoment.add(intermediate_bucket, duration);
+        }
+
+        //this replaces end_query as the final aggregation time
+        //end_query right endpoint already in the SQL where clause
+        buckets.push(intermediate_bucket);
+
+        _.each(buckets, (b, i) => {
+            this.logger.debug('time bucket ' + i, new Date(b.valueOf()).toISOString());
+        });
+
+        return buckets;
     }
 
     // query execution for timed/offset pagination
@@ -340,7 +335,7 @@ class ReadSql extends AdapterRead {
             }
             //perform time-based pagination if timeField is indicated
             if (this.timeField) {
-                var res = this.processPaginatedResults(points, this.timeField);
+                let res = this.processPaginatedResults(points, this.timeField);
                 res.readEnd = new JuttleMoment({rawDate: new Date(res.borderValue)});
                 return res;
             }
@@ -362,14 +357,14 @@ class ReadSql extends AdapterRead {
     //      - pass in an page of sorted results and specify the sort field
     //      - returns formatted points used and border value
     processPaginatedResults(resultsPage, sortField) {
-        var nonBorderPoints = [];
-        var len = resultsPage.length;
-        var borderValue = _.last(resultsPage)[sortField];
+        let nonBorderPoints = [];
+        let len = resultsPage.length;
+        let borderValue = _.last(resultsPage)[sortField];
         if (!borderValue) {
             throw new Error(`value of field "${sortField}" is ${typeof borderValue}`);
         }
 
-        for (var i = len - 2; i >= 0 ; i--) {
+        for (let i = len - 2; i >= 0 ; i--) {
             //use isEqual in order to compare Date objects correctly
             if (!_.isEqual(resultsPage[i][sortField], borderValue)) {
                 nonBorderPoints = resultsPage.slice(0, i + 1);
@@ -413,7 +408,7 @@ class ReadSql extends AdapterRead {
     }
 
     convertDatesToMoments(points) {
-        var timeField = this.timeField || 'time';
+        let timeField = this.timeField || 'time';
         _.each(points, function(pt) {
             if (_.isNumber(pt[timeField])) {
                 //sqlite return milliseconds in time field
@@ -428,8 +423,8 @@ class ReadSql extends AdapterRead {
     }
 
     omitNullAggregates(points) {
-        var result = [];
-        var bufferEmptyAggregates = [];
+        let result = [];
+        let bufferEmptyAggregates = [];
 
         _.each(points, (pt) => {
             if (_.isMatch(pt, this.empty_aggregate)) {

--- a/lib/read.js
+++ b/lib/read.js
@@ -1,20 +1,25 @@
 'use strict';
 
-var _ = require('underscore');
-var db = require('./db');
-var SQLFilter = require('./sql_filter');
-var FilterJSCompiler = require('juttle/lib/compiler/filters/filter-js-compiler');
-var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
-var Promise = require('bluebird');
-var AdapterRead = require('juttle/lib/runtime/adapter-read');
-var errors = require('juttle/lib/errors');
+/* global JuttleAdapterAPI */
+let AdapterRead = JuttleAdapterAPI.AdapterRead;
+let JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
+var errors = JuttleAdapterAPI.errors;
 
-const ALLOWED_OPTIONS = AdapterRead.commonOptions.concat(['table', 'raw', 'debug', 'fetchSize', 'optimize', 'db', 'id']);
+let _ = require('underscore');
+let Promise = require('bluebird');
+
+let db = require('./db');
+let FilterSQLCompiler = require('./sql_filter');
+
 const BATCHING_CONCURRENCY = 3;
 
 class ReadSql extends AdapterRead {
 
     static get FETCH_SIZE_LIMIT() { return 10000; }
+
+    static allowedOptions() {
+        return AdapterRead.commonOptions().concat(['table', 'raw', 'debug', 'fetchSize', 'optimize', 'db', 'id']);
+    }
 
     //initialization functions
 
@@ -56,31 +61,23 @@ class ReadSql extends AdapterRead {
     }
 
     validateOptions(options) {
-        var unknown = _.difference(_.keys(options), ALLOWED_OPTIONS);
-        if (unknown.length > 0) {
-            throw new errors.runtimeError('RT-UNKNOWN-OPTION-ERROR', {
-                proc: 'read-sql',
-                option: unknown[0]
-            });
-        }
-
         if (_.has(options, 'table') && _.has(options, 'raw') ||
             (_.has(options, 'debug') && _.has(options, 'raw'))
         ) {
-            throw new errors.runtimeError('RT-INCOMPATIBLE-OPTION-ERROR', {
+            throw new errors.runtimeError('INCOMPATIBLE-OPTION', {
                 option: 'raw',
                 other: 'table or -debug',
             });
         }
 
         if (!_.has(options, 'table') && !_.has(options, 'raw')) {
-            throw new errors.runtimeError('RT-MISSING-OPTION-ERROR', {
+            throw new errors.runtimeError('MISSING-OPTION', {
                 option: '-table or -raw',
                 proc: 'read-sql'
             });
         }
         if (options.timeField && !options.from && !options.to) {
-            throw new errors.runtimeError('RT-MISSING-OPTION-ERROR', {
+            throw new errors.runtimeError('MISSING-OPTION', {
                 option: '-from, -to, or -last when -timeField is specified',
                 proc: 'read-sql'
             });
@@ -98,7 +95,6 @@ class ReadSql extends AdapterRead {
     }
 
     addFilters(filter_ast) {
-        var FilterSQLCompiler = FilterJSCompiler.extend(SQLFilter);
         var compiler = new FilterSQLCompiler({ baseQuery: this.baseQuery });
         return compiler.compile(filter_ast);
     }
@@ -174,7 +170,7 @@ class ReadSql extends AdapterRead {
         .catch((err) => {
             if (/Pool (is|was) destroyed/.test(err.message)) {
                 var connectionInfo = this.baseQuery.client.connectionSettings;
-                throw errors.runtimeError('RT-INTERNAL-ERROR', {
+                throw errors.runtimeError('INTERNAL-ERROR', {
                     error: 'could not connect to database: ' + JSON.stringify(connectionInfo)
                 });
             } else {
@@ -409,7 +405,7 @@ class ReadSql extends AdapterRead {
         if (this.timeField &&
             (this.optimization_info.type !== 'reduce' || this.optimization_info.reduce_every)
         ) {
-            points = this.parseTime(points, this.timeField);
+            points = this.parseTime(points, { timeField: this.timeField });
         }
 
         this.total_emitted_points += points.length;

--- a/lib/read.js
+++ b/lib/read.js
@@ -3,7 +3,6 @@
 /* global JuttleAdapterAPI */
 let AdapterRead = JuttleAdapterAPI.AdapterRead;
 let JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
-let errors = JuttleAdapterAPI.errors;
 
 let _ = require('underscore');
 let Promise = require('bluebird');
@@ -67,20 +66,20 @@ class ReadSql extends AdapterRead {
         if (_.has(options, 'table') && _.has(options, 'raw') ||
             (_.has(options, 'debug') && _.has(options, 'raw'))
         ) {
-            throw new errors.runtimeError('INCOMPATIBLE-OPTION', {
+            throw this.runtimeError('INCOMPATIBLE-OPTION', {
                 option: 'raw',
                 other: 'table or -debug',
             });
         }
 
         if (!_.has(options, 'table') && !_.has(options, 'raw')) {
-            throw new errors.runtimeError('MISSING-OPTION', {
+            throw this.runtimeError('MISSING-OPTION', {
                 option: '-table or -raw',
                 proc: 'read-sql'
             });
         }
         if (options.timeField && !options.from && !options.to) {
-            throw new errors.runtimeError('MISSING-OPTION', {
+            throw this.runtimeError('MISSING-OPTION', {
                 option: '-from, -to, or -last when -timeField is specified',
                 proc: 'read-sql'
             });
@@ -172,7 +171,7 @@ class ReadSql extends AdapterRead {
         .catch((err) => {
             if (/Pool (is|was) destroyed/.test(err.message)) {
                 let connectionInfo = this.baseQuery.client.connectionSettings;
-                throw errors.runtimeError('INTERNAL-ERROR', {
+                throw this.runtimeError('INTERNAL-ERROR', {
                     error: 'could not connect to database: ' + JSON.stringify(connectionInfo)
                 });
             } else {
@@ -316,8 +315,8 @@ class ReadSql extends AdapterRead {
         //end_query right endpoint already in the SQL where clause
         buckets.push(intermediate_bucket);
 
-        _.each(buckets, (b, i) => {
-            this.logger.debug('time bucket ' + i, new Date(b.valueOf()).toISOString());
+        _.each(buckets, (bucket, index) => {
+            this.logger.debug('time bucket ' + index, new Date(bucket.valueOf()).toISOString());
         });
 
         return buckets;

--- a/lib/read.js
+++ b/lib/read.js
@@ -8,7 +8,6 @@ let errors = JuttleAdapterAPI.errors;
 let _ = require('underscore');
 let Promise = require('bluebird');
 
-let db = require('./db');
 let FilterSQLCompiler = require('./sql-filter');
 
 const BATCHING_CONCURRENCY = 3;
@@ -29,7 +28,7 @@ class ReadSql extends AdapterRead {
         this.setOptions(options);
 
         this.pointsBuffer = [];
-        this.baseQuery = db.getDbConnection(_.pick(options, 'db', 'id'));
+        this.baseQuery = this.getDbConnection(_.pick(options, 'db', 'id'));
 
         this.total_emitted_points = 0;
         this.maxSize = Infinity;
@@ -58,6 +57,10 @@ class ReadSql extends AdapterRead {
 
     periodicLiveRead() {
         return !!this.timeField;
+    }
+
+    getDbConnection() {
+        throw new Error('getDBConnection not implemented by adapter');
     }
 
     validateOptions(options) {

--- a/lib/sql-filter.js
+++ b/lib/sql-filter.js
@@ -1,17 +1,19 @@
 'use strict';
 
 /* global JuttleAdapterAPI */
-let FilterJSCompiler = JuttleAdapterAPI.compiler.ASTVisitor;
+let FilterASTCompiler = JuttleAdapterAPI.compiler.ASTVisitor;
 let errors = JuttleAdapterAPI.errors;
 
 const BINARY_OPS_TO_SQL_OPS = {
     '==':  '=',
     '!=':  '<>',
     '=~':  'LIKE',
-    '!~':  'NOT LIKE'
+    '!~':  'NOT LIKE',
+    'OR': 'orWhere',
+    'AND': 'andWhere'
 };
 
-class FilterSQLCompiler extends FilterJSCompiler {
+class FilterSQLCompiler extends FilterASTCompiler {
 
     constructor(options) {
         super(options);
@@ -26,15 +28,14 @@ class FilterSQLCompiler extends FilterJSCompiler {
         return this.visit(node.expression, sql_query);
     }
 
+
     visitBinaryExpression(node, sql_query) {
         let self = this;
         let SQL_OP = BINARY_OPS_TO_SQL_OPS[node.operator] || node.operator;
 
-        if (SQL_OP === 'OR' || SQL_OP === 'AND') {
-            let whereSpecfic = SQL_OP === 'OR' ? 'orWhere' : 'where';
-
+        if (SQL_OP === 'andWhere' || SQL_OP === 'orWhere') {
             return sql_query.where(function() {
-                return self.visit(node.left, this)[whereSpecfic](function() {
+                return self.visit(node.left, this)[SQL_OP](function() {
                     return self.visit(node.right, this);
                 });
             });
@@ -48,7 +49,7 @@ class FilterSQLCompiler extends FilterJSCompiler {
     }
 
     visitUnaryExpression(node, sql_query) {
-        let self = this;
+        var self = this;
 
         switch (node.operator) {
             case 'NOT':
@@ -56,7 +57,7 @@ class FilterSQLCompiler extends FilterJSCompiler {
                     return self.visit(node.argument, this);
                 });
             default:
-                throw new Error('Invalid operator: ' + node.operator + '.');
+                this.featureNotSupported(node, node.operator);
         }
     }
 

--- a/lib/sql-filter.js
+++ b/lib/sql-filter.js
@@ -1,7 +1,8 @@
 'use strict';
 
 /* global JuttleAdapterAPI */
-var FilterJSCompiler = JuttleAdapterAPI.compiler.FilterJSCompiler;
+let FilterJSCompiler = JuttleAdapterAPI.compiler.ASTVisitor;
+let errors = JuttleAdapterAPI.errors;
 
 const BINARY_OPS_TO_SQL_OPS = {
     '==':  '=',
@@ -26,11 +27,11 @@ class FilterSQLCompiler extends FilterJSCompiler {
     }
 
     visitBinaryExpression(node, sql_query) {
-        var self = this;
-        var SQL_OP = BINARY_OPS_TO_SQL_OPS[node.operator] || node.operator;
+        let self = this;
+        let SQL_OP = BINARY_OPS_TO_SQL_OPS[node.operator] || node.operator;
 
         if (SQL_OP === 'OR' || SQL_OP === 'AND') {
-            var whereSpecfic = SQL_OP === 'OR' ? 'orWhere' : 'where';
+            let whereSpecfic = SQL_OP === 'OR' ? 'orWhere' : 'where';
 
             return sql_query.where(function() {
                 return self.visit(node.left, this)[whereSpecfic](function() {
@@ -47,7 +48,7 @@ class FilterSQLCompiler extends FilterJSCompiler {
     }
 
     visitUnaryExpression(node, sql_query) {
-        var self = this;
+        let self = this;
 
         switch (node.operator) {
             case 'NOT':
@@ -68,7 +69,7 @@ class FilterSQLCompiler extends FilterJSCompiler {
     }
 
     visitArrayLiteral(node) {
-        var self = this;
+        let self = this;
         return node.elements.map(function(e) {
             return self.visit(e);
         });
@@ -76,6 +77,33 @@ class FilterSQLCompiler extends FilterJSCompiler {
 
     visitMomentLiteral(node) {
         return new Date(node.value);
+    }
+
+    visitNullLiteral(node) {
+        return null;
+    }
+
+    visitBooleanLiteral(node) {
+        return node.value;
+    }
+
+    visitNumberLiteral(node) {
+        return node.value;
+    }
+
+    visitInfinityLiteral(node) {
+        this.featureNotSupported(node, 'Infinity');
+    }
+
+    visitNaNLiteral(node) {
+        this.featureNotSupported(node, 'NaN');
+    }
+
+    featureNotSupported(node, feature) {
+        throw errors.compileError('FILTER-FEATURE-NOT-SUPPORTED', {
+            feature: feature,
+            location: node.location
+        });
     }
 }
 

--- a/lib/sql-filter.js
+++ b/lib/sql-filter.js
@@ -40,7 +40,7 @@ class FilterSQLCompiler extends FilterJSCompiler {
             });
         }
 
-        if (/LIKE/.test(SQL_OP)) {
+        if (/LIKE/.test(SQL_OP) && node.right.type === 'StringLiteral') {
             node.right.value = node.right.value.replace(/\*/g, '%').replace(/\?/g, '_');
         }
 
@@ -97,6 +97,10 @@ class FilterSQLCompiler extends FilterJSCompiler {
 
     visitNaNLiteral(node) {
         this.featureNotSupported(node, 'NaN');
+    }
+
+    visitRegExpLiteral(node) {
+        this.featureNotSupported(node, 'Regular Expressions');
     }
 
     featureNotSupported(node, feature) {

--- a/lib/sql_filter.js
+++ b/lib/sql_filter.js
@@ -1,23 +1,31 @@
-//override filter compilation with these functions.
+'use strict';
 
-var BINARY_OPS_TO_SQL_OPS = {
+/* global JuttleAdapterAPI */
+var FilterJSCompiler = JuttleAdapterAPI.compiler.FilterJSCompiler;
+
+const BINARY_OPS_TO_SQL_OPS = {
     '==':  '=',
     '!=':  '<>',
     '=~':  'LIKE',
     '!~':  'NOT LIKE'
 };
 
-module.exports = {
-    initialize: function(options) {
+class FilterSQLCompiler extends FilterJSCompiler {
+
+    constructor(options) {
+        super(options);
         this.baseQuery = options.baseQuery;
-    },
-    compile: function(node) {
+    }
+
+    compile(node) {
         return this.visit(node, this.baseQuery);
-    },
-    visitExpressionFilterTerm: function(node, sql_query) {
+    }
+
+    visitExpressionFilterTerm(node, sql_query) {
         return this.visit(node.expression, sql_query);
-    },
-    visitBinaryExpression: function(node, sql_query) {
+    }
+
+    visitBinaryExpression(node, sql_query) {
         var self = this;
         var SQL_OP = BINARY_OPS_TO_SQL_OPS[node.operator] || node.operator;
 
@@ -36,31 +44,39 @@ module.exports = {
         }
 
         return sql_query.where(this.visit(node.left), SQL_OP, this.visit(node.right));
-    },
-    visitUnaryExpression: function(node, sql_query) {
+    }
+
+    visitUnaryExpression(node, sql_query) {
         var self = this;
 
         switch (node.operator) {
             case 'NOT':
                 return sql_query.whereNot(function() {
-                    return self.visit(node.expression, this);
+                    return self.visit(node.argument, this);
                 });
-            case '*':
-                return this.visit(node.expression);
             default:
                 throw new Error('Invalid operator: ' + node.operator + '.');
         }
-    },
-    visitStringLiteral: function(node) {
+    }
+
+    visitField(node) {
+        return node.name;
+    }
+
+    visitStringLiteral(node) {
         return String(node.value);
-    },
-    visitArrayLiteral: function(node) {
+    }
+
+    visitArrayLiteral(node) {
         var self = this;
         return node.elements.map(function(e) {
             return self.visit(e);
         });
-    },
-    visitMomentLiteral: function(node) {
+    }
+
+    visitMomentLiteral(node) {
         return new Date(node.value);
     }
-};
+}
+
+module.exports = FilterSQLCompiler;

--- a/lib/write.js
+++ b/lib/write.js
@@ -9,13 +9,11 @@ let logger = JuttleAdapterAPI.getLogger('sql-db-write');
 let _ = require('underscore');
 let Promise = require('bluebird');
 
-let db = require('./db');
-
 class WriteSql extends AdapterWrite {
     constructor(options, params) {
         super(options, params);
         this.handleOptions(options);
-        this.knex = db.getDbConnection(_.pick(options, 'db', 'id'));
+        this.knex = this.getDbConnection(_.pick(options, 'db', 'id'));
         this.inserts_in_progress = 0;
         this.eof_received = false;
         this.writePromise = Promise.resolve();
@@ -23,6 +21,10 @@ class WriteSql extends AdapterWrite {
 
     static allowedOptions() {
         return ['table', 'db', 'id'];
+    }
+
+    getDbConnection() {
+        throw new Error('getDBConnection not implemented by adapter');
     }
 
     handleOptions(options) {

--- a/lib/write.js
+++ b/lib/write.js
@@ -2,7 +2,6 @@
 
 /* global JuttleAdapterAPI */
 let AdapterWrite = JuttleAdapterAPI.AdapterWrite;
-let errors = JuttleAdapterAPI.errors;
 let values = JuttleAdapterAPI.runtime.values;
 let logger = JuttleAdapterAPI.getLogger('sql-db-write');
 
@@ -31,7 +30,7 @@ class WriteSql extends AdapterWrite {
         logger.debug('init options:', options);
 
         if (!_.has(options, 'table')) {
-            throw new errors.compileError('REQUIRED-OPTION', {
+            throw this.compileError('REQUIRED-OPTION', {
                 proc: 'write-sql',
                 option: "table"
             });
@@ -50,7 +49,7 @@ class WriteSql extends AdapterWrite {
         }).catch((err) => {
             if (/Pool (is|was) destroyed/.test(err.message)) {
                 let connectionInfo = this.knex.client.connectionSettings;
-                err = errors.runtimeError('INTERNAL-ERROR', {
+                err = this.runtimeError('INTERNAL-ERROR', {
                     error: 'could not connect to database: ' + JSON.stringify(connectionInfo)
                 });
             }
@@ -65,7 +64,7 @@ class WriteSql extends AdapterWrite {
             });
 
             if (deep) {
-                this.trigger('warning', new errors.runtimeError('INTERNAL-ERROR', {
+                this.trigger('warning', this.runtimeError('INTERNAL-ERROR', {
                     error: 'Serializing array and object fields is not supported.'
                 }));
             }

--- a/lib/write.js
+++ b/lib/write.js
@@ -1,14 +1,15 @@
 'use strict';
 
-var _ = require('underscore');
-var AdapterWrite = require('juttle/lib/runtime/adapter-write');
-var errors = require('juttle/lib/errors');
-var db = require('./db');
-var values = require('juttle/lib/runtime/values');
-var Promise = require('bluebird');
-var logger = require('juttle/lib/logger').getLogger('sql-db-write');
+/* global JuttleAdapterAPI */
+let AdapterWrite = JuttleAdapterAPI.AdapterWrite;
+let errors = JuttleAdapterAPI.errors;
+let values = JuttleAdapterAPI.runtime.values;
+let logger = JuttleAdapterAPI.getLogger('sql-db-write');
 
-const ALLOWED_OPTIONS = ['table', 'db', 'id'];
+let _ = require('underscore');
+let Promise = require('bluebird');
+
+let db = require('./db');
 
 class WriteSql extends AdapterWrite {
     constructor(options, params) {
@@ -20,18 +21,15 @@ class WriteSql extends AdapterWrite {
         this.writePromise = Promise.resolve();
     }
 
+    static allowedOptions() {
+        return ['table', 'db', 'id'];
+    }
+
     handleOptions(options) {
         logger.debug('init options:', options);
-        var unknown = _.difference(_.keys(options), ALLOWED_OPTIONS);
-        if (unknown.length > 0) {
-            throw new errors.compileError('RT-UNKNOWN-OPTION-ERROR', {
-                proc: 'write-sql',
-                option: unknown[0]
-            });
-        }
 
         if (!_.has(options, 'table')) {
-            throw new errors.compileError('RT-REQUIRED-OPTION-ERROR', {
+            throw new errors.compileError('REQUIRED-OPTION', {
                 proc: 'write-sql',
                 option: "table"
             });
@@ -50,7 +48,7 @@ class WriteSql extends AdapterWrite {
         }).catch((err) => {
             if (/Pool (is|was) destroyed/.test(err.message)) {
                 var connectionInfo = this.knex.client.connectionSettings;
-                err = errors.runtimeError('RT-INTERNAL-ERROR', {
+                err = errors.runtimeError('INTERNAL-ERROR', {
                     error: 'could not connect to database: ' + JSON.stringify(connectionInfo)
                 });
             }
@@ -65,7 +63,7 @@ class WriteSql extends AdapterWrite {
             });
 
             if (deep) {
-                this.trigger('warning', new errors.runtimeError('RT-INTERNAL-ERROR', {
+                this.trigger('warning', new errors.runtimeError('INTERNAL-ERROR', {
                     error: 'Serializing array and object fields is not supported.'
                 }));
             }

--- a/lib/write.js
+++ b/lib/write.js
@@ -43,11 +43,11 @@ class WriteSql extends AdapterWrite {
             return;
         }
         this.writePromise = this.writePromise.then(() => {
-            var formattedPoints = this.formatPoints(points);
+            let formattedPoints = this.formatPoints(points);
             return this.insertPoints(formattedPoints);
         }).catch((err) => {
             if (/Pool (is|was) destroyed/.test(err.message)) {
-                var connectionInfo = this.knex.client.connectionSettings;
+                let connectionInfo = this.knex.client.connectionSettings;
                 err = errors.runtimeError('INTERNAL-ERROR', {
                     error: 'could not connect to database: ' + JSON.stringify(connectionInfo)
                 });
@@ -58,7 +58,7 @@ class WriteSql extends AdapterWrite {
 
     formatPoints(points) {
         points = _.filter(points, (pt) => {
-            var deep = _.some(pt, function(value, key) {
+            let deep = _.some(pt, function(value, key) {
                 return values.isObject(value) || values.isArray(value);
             });
 

--- a/package.json
+++ b/package.json
@@ -32,9 +32,7 @@
     "istanbul": "^0.4.2",
     "mocha": "^2.3.4"
   },
-  "peerDependencies": {
-    "juttle": ">=0.4.0"
-  },
+  "juttleAdapterAPI": "^0.5.0",
   "engines": {
     "node": ">=4.2.0",
     "npm": ">=2.14.7"

--- a/sqlite-db.js
+++ b/sqlite-db.js
@@ -1,0 +1,39 @@
+// Db connection retreival for sqlite.
+// This class must live in this repo because it used for unit tests.
+// This class is also used by the juttle-sqlite-adapter for code-reuse purposes.
+
+'use strict';
+
+let _ = require('underscore');
+let Knex = require('knex');
+
+let SqlCommonDB = require('./lib/db');
+
+var REQUIRED_CONFIG_PROPERTIES = ['filename'];
+
+class DB extends SqlCommonDB {
+
+    static getKnex(singleDBConfig, options) {
+
+        options = options || {};
+        if (options.db) {
+            singleDBConfig.filename = options.db;
+        }
+
+        _.each(REQUIRED_CONFIG_PROPERTIES, function(prop) {
+            if (!singleDBConfig.hasOwnProperty(prop)) {
+                throw new Error('Each configuration must contain a field: ' + prop);
+            }
+        });
+
+        var connection = {
+            filename: singleDBConfig.filename
+        };
+
+        return Knex({
+            "client": "sqlite3",
+            "connection": connection
+        });
+    }
+}
+module.exports = DB;

--- a/test/conf.js
+++ b/test/conf.js
@@ -1,36 +1,8 @@
 // Configuration for testing common code only.
 
-var _ = require('underscore');
-var juttle_test_utils = require('juttle/test').utils;
-
-var REQUIRED_CONFIG_PROPERTIES = ['filename'];
-
-juttle_test_utils.withAdapterAPI(function() {
-
-    var db = require('../lib/db');
-
-    db.getKnex = function(singleDBConfig, options) {
-        options = options || {};
-        if (options.db) {
-            singleDBConfig.filename = options.db;
-        }
-
-        _.each(REQUIRED_CONFIG_PROPERTIES, function(prop) {
-            if (!singleDBConfig.hasOwnProperty(prop)) {
-                throw new Error('Each configuration must contain a field: ' + prop);
-            }
-        });
-
-        var connection = {
-            filename: singleDBConfig.filename
-        };
-
-        return require('knex')({
-            "client": "sqlite3",
-            "connection": connection
-        });
-    };
-});
+function getDBClass() {
+    return require('../sqlite-db');
+}
 
 function getAdapterName() {
     return 'sql';
@@ -52,6 +24,7 @@ function getAdapterConfig() {
 }
 
 module.exports = {
+    getDBClass: getDBClass,
     getAdapterName: getAdapterName,
     getAdapterConfig: getAdapterConfig
 };

--- a/test/conf.js
+++ b/test/conf.js
@@ -1,0 +1,57 @@
+// Configuration for testing common code only.
+
+var _ = require('underscore');
+var juttle_test_utils = require('juttle/test').utils;
+
+var REQUIRED_CONFIG_PROPERTIES = ['filename'];
+
+juttle_test_utils.withAdapterAPI(function() {
+
+    var db = require('../lib/db');
+
+    db.getKnex = function(singleDBConfig, options) {
+        options = options || {};
+        if (options.db) {
+            singleDBConfig.filename = options.db;
+        }
+
+        _.each(REQUIRED_CONFIG_PROPERTIES, function(prop) {
+            if (!singleDBConfig.hasOwnProperty(prop)) {
+                throw new Error('Each configuration must contain a field: ' + prop);
+            }
+        });
+
+        var connection = {
+            filename: singleDBConfig.filename
+        };
+
+        return require('knex')({
+            "client": "sqlite3",
+            "connection": connection
+        });
+    };
+});
+
+function getAdapterName() {
+    return 'sql';
+}
+
+function getAdapterConfig() {
+    var config = [
+        {
+            id: 'default',
+            filename: "./unit-test.sqlite"
+        }, {
+            id: 'fake',
+            filename: "./not_dir/should_not_work/not_db.sqlite"
+        }
+    ];
+    config.path = "./";
+
+    return config;
+}
+
+module.exports = {
+    getAdapterName: getAdapterName,
+    getAdapterConfig: getAdapterConfig
+};

--- a/test/filters.spec.js
+++ b/test/filters.spec.js
@@ -2,6 +2,7 @@ require('./shared');
 var expect = require('chai').expect;
 var TestUtils = require("./utils");
 var check_success = TestUtils.check_juttle_success;
+var check_juttle_error = TestUtils.check_juttle_error;
 
 describe('test filters', function () {
     before(function() {
@@ -165,6 +166,31 @@ describe('test filters', function () {
         })
         .then(function(result) {
             expect(result.sinks.table).to.have.length.within(9,11);
+        });
+    });
+
+    it('sql filters with Infinity', function() {
+        return check_juttle_error({
+            program: 'read sql -table "logs" code > Infinity'
+        })
+        .catch(function(err) {
+            expect(err.message).to.contain('Filters do not support Infinity');
+        });
+    });
+    it('sql filters with NaN', function() {
+        return check_juttle_error({
+            program: 'read sql -table "logs" code > NaN'
+        })
+        .catch(function(err) {
+            expect(err.message).to.contain('Filters do not support NaN');
+        });
+    });
+    it('sql filters with RegExp', function() {
+        return check_juttle_error({
+            program: 'read sql -table "logs" code =~ /2/'
+        })
+        .catch(function(err) {
+            expect(err.message).to.contain('Filters do not support Regular Expressions');
         });
     });
 });

--- a/test/options.spec.js
+++ b/test/options.spec.js
@@ -62,9 +62,6 @@ describe('test options', function () {
         return TestUtils.check_juttle_error({
             program: 'read sql level = "error"'
         })
-        .then(function() {
-            throw new Error('We should not get this error');
-        })
         .catch(function(result) {
             expect(result.message).to.contain("required option -table or -raw.");
         });
@@ -72,9 +69,6 @@ describe('test options', function () {
     it('incompatable option error', function() {
         return TestUtils.check_juttle_error({
             program: 'read sql -table "test" -raw "RAW SQL" level = "error"'
-        })
-        .then(function() {
-            throw new Error('We should not get this error');
         })
         .catch(function(result) {
             expect(result.message).to.contain("-raw option should not be combined with");

--- a/test/shared.js
+++ b/test/shared.js
@@ -1,7 +1,10 @@
 var TestUtils = require("./utils");
+var juttle_test_utils = require('juttle/test').utils;
 
 before(function() {
-    return TestUtils.init();
+    return juttle_test_utils.withAdapterAPI(function() {
+        TestUtils.init();
+    });
 });
 after(function() {
     return TestUtils.removeTables();

--- a/test/time.spec.js
+++ b/test/time.spec.js
@@ -81,14 +81,11 @@ describe('test time usage', function () {
         });
     });
     it('sql with timeField but no to/from', function() {
-        return check_juttle({
+        return TestUtils.check_juttle_error({
             program: 'read sql -timeField "time" -table "logs"'
         })
-        .then(function() {
-            throw new Error('We should not get this error');
-        })
-        .catch(function(result) {
-            expect(result.message).to.contain("required option -from, -to, or -last when -timeField is specified");
+        .catch(function(err) {
+            expect(err.message).to.contain("required option -from, -to, or -last when -timeField is specified");
         });
     });
     it('sql time usage with same timeField without pagination', function() {

--- a/test/utils.js
+++ b/test/utils.js
@@ -35,15 +35,13 @@ var TestUtils = {
         }
         tableCreationMap = TestUtils.getTableCreationMap();
     },
-
     initTestDbConnection: function() {
-        juttle_test_utils.withAdapterAPI(function(){
-            db = require('../lib/db');
+        juttle_test_utils.withAdapterAPI(() => {
+            db = this.getDBClass();
             db.init(TestUtils.getAdapterConfig());
             knex = db.getDbConnection();
         });
     },
-
     getTableCreationMap: function() {
         return {
             logs: function() { return TestUtils.createLogTable('logs', 'time', sampleData.logs); },

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,39 +1,47 @@
 var sampleData = require("./sample_data");
 var Promise = require('bluebird');
 var _ = require('underscore');
-var juttle_test_utils = require('juttle/test/runtime/specs/juttle-test-utils');
-var check_juttle = juttle_test_utils.check_juttle;
+var juttle_test_utils = require('juttle/test').utils;
+var check_juttle = juttle_test_utils.checkJuttle;
 var expect = require('chai').expect;
-var Juttle = require('juttle/lib/runtime').Juttle;
 var logger = require('juttle/lib/logger').getLogger('sql-test-util');
-var db = require('../lib/db');
 
+var db;
 var knex;
-var adapter;
+var adapterName;
 var createdTables = [];
 var tableCreationMap;
 
 var TestUtils = {
     init: function () {
-        if (adapter) { return; }
+        if (adapterName) { return; }
 
-        var AdapterClass = TestUtils.getAdapterClass();
         var config = TestUtils.getAdapterConfig();
+        adapterName = TestUtils.getAdapterName();
 
-        adapter = AdapterClass(config);
+        logger.info('Testing ' + adapterName + ' adapter.');
 
-        logger.info('Testing ' + adapter.name + ' adapter.');
-
-        knex = db.getDbConnection();
+        TestUtils.initTestDbConnection();
 
         try {
-            Juttle.adapters.register(adapter.name, adapter);
+            var confParams = {};
+            confParams[adapterName] = config;
+
+            juttle_test_utils.configureAdapter(confParams);
         } catch (err) {
             if (!err.message.includes('already registered')) {
                 throw err;
             }
         }
         tableCreationMap = TestUtils.getTableCreationMap();
+    },
+
+    initTestDbConnection: function() {
+        juttle_test_utils.withAdapterAPI(function(){
+            db = require('../lib/db');
+            db.init(TestUtils.getAdapterConfig());
+            knex = db.getDbConnection();
+        });
     },
 
     getTableCreationMap: function() {
@@ -45,41 +53,8 @@ var TestUtils = {
             sqlwriter: function() { return TestUtils.createWritingTable(); }
         };
     },
-
-    // override Class and Config in each repo that uses the sql common tests.
-    getAdapterClass: function() {
-        db.getKnex = function(config, options) {
-            options = options || {};
-
-            var connection = {
-                filename: config.filename
-            };
-            if (options.db) {
-                connection.filename = options.db;
-            }
-            return require('knex')({
-                "client": "sqlite3",
-                "connection": connection
-            });
-        };
-        return  require('../');
-    },
-    getAdapterConfig: function() {
-        return [
-            {
-                id: 'default',
-                filename: "./unit-test.sqlite"
-            }, {
-                id: 'fake',
-                filename: "./not_dir/should_not_work/not_db.sqlite"
-            }
-        ];
-    },
     getSampleData: function () {
         return sampleData;
-    },
-    getAdapterName: function () {
-        return adapter.name;
     },
     createTables: function (createTableNames) {
         return Promise.try(function() {
@@ -108,7 +83,7 @@ var TestUtils = {
         });
     },
     clearState: function() {
-        adapter = null;
+        adapterName = '';
         if (knex) {
             return TestUtils.removeTables()
             .then(function() {
@@ -208,7 +183,7 @@ var TestUtils = {
         });
     },
     check_sql_juttle: function(params, deactivateAfter) {
-        params.program = params.program.replace(' sql ', ' ' + adapter.name + ' ');
+        params.program = params.program.replace(' sql ', ' ' + adapterName + ' ');
         return check_juttle(params, deactivateAfter);
     },
     check_juttle_success: function(params, deactivateAfter) {
@@ -252,4 +227,5 @@ var TestUtils = {
     }
 };
 
+_.extend(TestUtils, require('./conf'));
 module.exports = TestUtils;


### PR DESCRIPTION
Goals:
1. Use new adapter API.
2. Use juttle-test-utils configure function to register adapter for unit testing.
3. Use separate conf file for test configurations instead of including that information in `TestUtils` Object.
4. Use new `allowedOptions` shared logic.
5. ES6ed Filter class extending from `FilterJSCompiler` available from AdapterAPI.
6. Change optimize class based on graph changes to reduce node.type name and Field.
7. ES6-ify everything.
8. Refactor db object into a class with static methods extended by each subclass.

A +1 here also means a +1 on https://github.com/juttle/juttle-postgres-adapter/pull/23.

fixes https://github.com/juttle/juttle-sql-adapter-common/issues/24
fixes https://github.com/juttle/juttle-sql-adapter-common/issues/9
fixes https://github.com/juttle/juttle-sql-adapter-common/issues/37
