### PR TITLE
support juttle 0.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ node_js:
     - '4.2'
 
 before_script:
-    - npm install juttle@^0.6.0
+    - npm install juttle@^0.7.0
 
 script:
     - npm run test-coverage

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "moment": "^2.12.0",
     "sqlite3": "^3.1.1"
   },
-  "juttleAdapterAPI": "^0.5.0",
+  "juttleAdapterAPI": "^0.7.0",
   "engines": {
     "node": ">=4.2.0",
     "npm": ">=2.14.7"

--- a/package.json
+++ b/package.json
@@ -25,12 +25,13 @@
     "bluebird": "^3.0.5"
   },
   "devDependencies": {
-    "sqlite3": "^3.1.1",
-    "knex": "^0.9.0",
     "chai": "^1.10.0",
     "eslint": "^1.10.3",
     "istanbul": "^0.4.2",
-    "mocha": "^2.3.4"
+    "knex": "^0.9.0",
+    "mocha": "^2.3.4",
+    "moment": "^2.12.0",
+    "sqlite3": "^3.1.1"
   },
   "juttleAdapterAPI": "^0.5.0",
   "engines": {

--- a/test/sample_data.js
+++ b/test/sample_data.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var moment = require('moment');
 var tableData = {};
 
 var logs = [];
@@ -9,9 +10,7 @@ var temp;
 for (var i = 150 ; i > 0 ; i--) {
     isErrLog = Math.round(Math.random()); // 0 or 1
 
-    temp = new Date();
-    temp.setDate(today.getDate() - i);
-
+    temp = moment.utc().subtract(i, 'days').toDate();
     logs.push({
         time: temp,
         host: "127.0.0." + (Math.round(Math.random()) + 1),


### PR DESCRIPTION
Bump the version in the JuttleAdapterAPI and travis.

Also fix up the test code so it properly generates timestamped points that don't mess up when the time range spans the daylight savings time shift.
